### PR TITLE
Inline dependency versions for dependabot updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,6 @@ plugins {
     id("signing")
 }
 
-val protobufVersion by extra("3.12.2")
-
 subprojects {
     apply(plugin = "java-library")
     apply(plugin = "io.freefair.lombok")
@@ -41,7 +39,7 @@ subprojects {
 
     protobuf {
         protoc {
-            artifact = "com.google.protobuf:protoc:$protobufVersion"
+            artifact = "com.google.protobuf:protoc:3.12.2"
         }
     }
 

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -13,7 +13,7 @@ sourceSets {
 }
 
 dependencies {
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    implementation("com.google.protobuf:protobuf-java:3.12.2")
     implementation("org.apache.kafka:kafka-clients:2.5.0")
     implementation("org.springframework:spring-core:5.2.6.RELEASE")
     implementation("org.slf4j:slf4j-api:1.7.30")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -8,21 +8,15 @@ java {
 }
 
 dependencies {
-    val springVersion = "5.3.3"
-    val springDataVersion = "2.1.4"
-    val kafkaVersion = "2.5.0"
-    val springKafkaVersion = "2.5.4.RELEASE"
-    val testcontainersVersion = "1.17.5"
-    val log4jVersion = "2.13.3"
 
-    implementation("org.springframework:spring-context:$springVersion")
+    implementation("org.springframework:spring-context:5.3.3")
 
-    implementation("org.springframework.data:spring-data-relational:$springDataVersion")
+    implementation("org.springframework.data:spring-data-relational:2.1.4")
     implementation("org.springframework.data:spring-data-r2dbc:1.2.3")
-    implementation("org.springframework:spring-r2dbc:$springVersion")
+    implementation("org.springframework:spring-r2dbc:5.3.3")
     implementation("io.r2dbc:r2dbc-postgresql:0.8.7.RELEASE")
-    implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    implementation("org.apache.kafka:kafka-clients:2.5.0")
+    implementation("com.google.protobuf:protobuf-java:3.12.2")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:1.7.30")
@@ -30,25 +24,25 @@ dependencies {
 
     // testing
     testImplementation("org.springframework.boot:spring-boot-autoconfigure:2.4.2")
-    testImplementation("org.springframework:spring-test:$springVersion")
+    testImplementation("org.springframework:spring-test:5.3.3")
     testImplementation("io.projectreactor:reactor-test:3.4.3")
     testImplementation(platform("org.junit:junit-bom:5.7.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.hamcrest:hamcrest:2.2")
-    testImplementation("org.testcontainers:junit-jupiter:$testcontainersVersion")
-    testImplementation("org.springframework:spring-jdbc:$springVersion")
+    testImplementation("org.testcontainers:junit-jupiter:1.17.5")
+    testImplementation("org.springframework:spring-jdbc:5.3.3")
     testImplementation("io.r2dbc:r2dbc-pool:0.8.6.RELEASE")
-    testImplementation("org.testcontainers:postgresql:$testcontainersVersion")
-    testImplementation("org.testcontainers:kafka:$testcontainersVersion")
-    testImplementation("org.testcontainers:toxiproxy:$testcontainersVersion")
+    testImplementation("org.testcontainers:postgresql:1.17.5")
+    testImplementation("org.testcontainers:kafka:1.17.5")
+    testImplementation("org.testcontainers:toxiproxy:1.17.5")
     // update gson version to fix a conflict of toxiproxy dependency and spring GsonAutoConfiguration
     testRuntimeOnly("com.google.code.gson:gson:2.10")
     testImplementation("org.postgresql:postgresql:42.5.0")
     testImplementation("org.flywaydb:flyway-core:9.7.0")
     testImplementation("org.flywaydb.flyway-test-extensions:flyway-spring-test:7.0.0")
-    testImplementation("org.springframework.kafka:spring-kafka:$springKafkaVersion")
-    testImplementation("org.springframework.kafka:spring-kafka-test:$springKafkaVersion")
+    testImplementation("org.springframework.kafka:spring-kafka:2.5.4.RELEASE")
+    testImplementation("org.springframework.kafka:spring-kafka-test:2.5.4.RELEASE")
     testImplementation("org.awaitility:awaitility:4.0.3")
-    testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-    testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.13.3")
+    testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
 }

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -8,19 +8,14 @@ java {
 }
 
 dependencies {
-    val springVersion = "5.2.8.RELEASE"
-    val hibernateVersion = "5.4.18.Final"
-    val kafkaVersion = "2.5.0"
-    val springKafkaVersion = "2.5.4.RELEASE"
-    val log4jVersion = "2.13.3"
-
-    implementation("org.springframework:spring-context:$springVersion")
-    implementation("org.springframework:spring-orm:$springVersion")
-    implementation("org.hibernate:hibernate-core:$hibernateVersion")
-    implementation("org.hibernate:hibernate-java8:$hibernateVersion")
+    
+    implementation("org.springframework:spring-context:5.2.8.RELEASE")
+    implementation("org.springframework:spring-orm:5.2.8.RELEASE")
+    implementation("org.hibernate:hibernate-core:5.4.18.Final")
+    implementation("org.hibernate:hibernate-java8:5.4.18.Final")
     implementation("com.vladmihalcea:hibernate-types-52:2.10.2")
-    implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    implementation("org.apache.kafka:kafka-clients:2.5.0")
+    implementation("com.google.protobuf:protobuf-java:3.12.2")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:1.7.30")
     implementation("javax.annotation:javax.annotation-api:1.3.2")
@@ -28,15 +23,15 @@ dependencies {
     // testing
     testImplementation("junit:junit:4.13")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.7.0")
-    testImplementation("org.springframework:spring-test:$springVersion")
+    testImplementation("org.springframework:spring-test:5.2.8.RELEASE")
     testImplementation("org.testcontainers:postgresql:1.17.5")
     testImplementation("org.postgresql:postgresql:42.5.0")
     testImplementation("org.flywaydb:flyway-core:9.7.0")
     testImplementation("org.flywaydb.flyway-test-extensions:flyway-spring-test:7.0.0")
-    testImplementation("org.springframework.kafka:spring-kafka:$springKafkaVersion")
-    testImplementation("org.springframework.kafka:spring-kafka-test:$springKafkaVersion")
-    testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
-    testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+    testImplementation("org.springframework.kafka:spring-kafka:2.5.4.RELEASE")
+    testImplementation("org.springframework.kafka:spring-kafka-test:2.5.4.RELEASE")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.13.3")
+    testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
 }
 
 // conflict of vladmihalcea regarding jackson:


### PR DESCRIPTION
Right now, with extracted variables for artifact versions, dependabot is not able to propose updates. With this change updates via dependabot should be happening.