### PR TITLE
Fix outbox processor integration test, improve REAMDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The application stores the serialized message that shall be published (to a cert
 The library continuously processes the outbox and publishes the serialized message together with some headers
 to the specified topic. Messages are published with the following guarantees:
 * *strict ordering*: i.e. messages are published in the order
-they're stored in the outbox. In consequence, if a message could not be published, it will not try to publish the next message.
+they're stored in the outbox. In consequence, if a message could not be published, it will not try to publish the next message. *Note*: for this the kafka producer must have set `max.in.flight.requests.per.connection = 1`, which is set automatically in the default setup as shown below.
 * *at-least-once delivery*: every message from the outbox is published at least once, i.e. in case of errors (e.g. database unavailability or network errors) there may be duplicates. Consumers are responsible for deduplication.
 
 Messages are published with the headers `x-value-type`, `x-sequence` and `x-source`:
@@ -108,6 +108,8 @@ per instance).
 The `OutboxProcessor` is the component which processes the outbox and publishes messages/events to Kafka, once it could
  obtain the lock. If it could not obtain the lock on startup, it will continuously monitor the lock and try to obtain
  it (in case the lock-holding instance crashed or could not longer refresh the lock).
+
+*Note*: so that messages are published in-order as expected, the producer must be configured with `max.in.flight.requests.per.connection = 1`. If you're using the `DefaultKafkaProducerFactory` as shown below, the provided `producerProps` should either have *not* set `max.in.flight.requests.per.connection` (then it would be set by `DefaultKafkaProducerFactory`) or it must be set to `1`.
 
 #### Setup the `OutboxProcessor` from `outbox-kafka-spring` (classic projects)
 

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/KafkaTestSupport.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/KafkaTestSupport.java
@@ -109,7 +109,11 @@ public interface KafkaTestSupport {
     }
 
     static void assertConsumedRecord(OutboxRecord outboxRecord, String sourceHeaderValue, ConsumerRecord<String, byte[]> kafkaRecord) {
-        assertEquals(outboxRecord.getId().longValue(), toLong(kafkaRecord.headers().lastHeader(HEADERS_SEQUENCE_NAME).value()));
+        assertEquals(
+                outboxRecord.getId().longValue(),
+                toLong(kafkaRecord.headers().lastHeader(HEADERS_SEQUENCE_NAME).value()),
+                "OutboxRecord id and " + HEADERS_SEQUENCE_NAME + " headers do not match"
+        );
         assertArrayEquals(sourceHeaderValue.getBytes(), kafkaRecord.headers().lastHeader(HEADERS_SOURCE_NAME).value());
         outboxRecord.getHeadersAsMap().forEach((key, value) ->
                 assertArrayEquals(value.getBytes(), kafkaRecord.headers().lastHeader(key).value())


### PR DESCRIPTION
* Fix OutboxProcessorIntegrationTest to cut connections
    
    The connection to the database or kafka was actually not cut
    (because the `Mono` returned by `doOnNext` was not `subscribe`d).
    
    The `Mono` returned by `repository.save` now has to be `cache`d, so that
    it can be consumed twice (also by `getSortedById`).
    
    Also remove the `producerProps.put(RETRIES_CONFIG, 0)` because it
    doesn't reduce time (as the comment suggests), and changes the default
    behavior/config compared to the settings of
    `DefaultKafkaProducerFactory`.
    
    This test shows the proper functionality that was questioned by issue #39.
    
    The expected in-order publishing (tested by
    `should_processRecordsInOrder_whenKafkaIsTemporarilyNotAvailable`) can actually
    be broken by changing the `producerProps` used by that test like this
    (in `OutboxProcessorIntegrationTest` line 255ff):
    ```
    producerProps.put(REQUEST_TIMEOUT_MS_CONFIG, (int) requestTimeout.toMillis()); // unchanged
    producerProps.put(MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 6); // > 5
    ```
    With `MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION > 5`, for the producer
    idempotence will be disabled automatically, i.e. another way to break
    in-order publishing would be to set
    ```
    producerProps.put(ENABLE_IDEMPOTENCE_CONFIG, false);
    ```
    (with e.g. `MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION = 5`)

* Improve README regarding in-order messaging guarantee
    
    While it's automatically set by `DefaultKafkaProducerFactory`, it's good
    to explicitely point to that.