### PR TITLE
Resolve #56: Spring major version update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
 project(":commons").version = "1.0.3-SNAPSHOT"
-project(":outbox-kafka-spring").version = "1.1.7-SNAPSHOT"
-project(":outbox-kafka-spring-reactive").version = "1.0.14-SNAPSHOT"
+project(":outbox-kafka-spring").version = "2.0.0-SNAPSHOT"
+project(":outbox-kafka-spring-reactive").version = "2.0.0-SNAPSHOT"
 
 plugins {
     id("java-library")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
-project(":commons").version = "1.0.3-SNAPSHOT"
+project(":commons").version = "2.0.0-SNAPSHOT"
 project(":outbox-kafka-spring").version = "2.0.0-SNAPSHOT"
 project(":outbox-kafka-spring-reactive").version = "2.0.0-SNAPSHOT"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ subprojects {
     group = "one.tomorrow.transactional-outbox"
 
     java {
+        sourceCompatibility = JavaVersion.VERSION_17
+
         withJavadocJar()
         withSourcesJar()
     }

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -1,8 +1,6 @@
 
 // the version is set in parent/root build.gradle.kts
 
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("org.apache.kafka:kafka-clients:3.3.1")

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -6,7 +6,7 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("org.apache.kafka:kafka-clients:3.3.1")
-    implementation("org.springframework:spring-core:5.3.23")
+    implementation("org.springframework:spring-core:6.0.2")
     implementation("org.slf4j:slf4j-api:2.0.7")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.1")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -8,7 +8,7 @@ java {
 }
 
 dependencies {
-    val springVersion = "5.3.23"
+    val springVersion = "6.0.2"
     val springDataVersion = "3.0.0"
     val kafkaVersion = "3.3.1"
     val springKafkaVersion = "3.0.0"

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("org.springframework.data:spring-data-relational:$springDataVersion")
     implementation("org.springframework.data:spring-data-r2dbc:3.0.0")
     implementation("org.springframework:spring-r2dbc:$springVersion")
-    implementation("io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE")
+    implementation("org.postgresql:r2dbc-postgresql:1.0.0.RELEASE")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
     implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.14.1")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation("org.springframework:spring-context:$springVersion")
 
     implementation("org.springframework.data:spring-data-relational:$springDataVersion")
-    implementation("org.springframework.data:spring-data-r2dbc:1.5.5")
+    implementation("org.springframework.data:spring-data-r2dbc:3.0.0")
     implementation("org.springframework:spring-r2dbc:$springVersion")
     implementation("io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -2,7 +2,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    val springVersion = "6.0.7"
+    val springVersion = "6.0.8"
     val springDataVersion = "3.0.0"
     val kafkaVersion = "3.4.0"
     val springKafkaVersion = "3.0.5"

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -26,8 +26,11 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-autoconfigure:3.0.0")
     testImplementation("org.springframework:spring-test:$springVersion")
     testImplementation("io.projectreactor:reactor-test:3.5.3")
-    testImplementation(platform("org.junit:junit-bom:5.9.1"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
+
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("org.testcontainers:junit-jupiter:$testcontainersVersion")
     testImplementation("org.springframework:spring-jdbc:$springVersion")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -1,12 +1,6 @@
 
 // the version is set in parent/root build.gradle.kts
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
-}
-
 dependencies {
     val springVersion = "6.0.2"
     val springDataVersion = "3.0.0"

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -9,7 +9,7 @@ java {
 
 dependencies {
     val springVersion = "5.3.23"
-    val springDataVersion = "2.4.5"
+    val springDataVersion = "3.0.0"
     val kafkaVersion = "3.3.1"
     val springKafkaVersion = "2.9.2"
     val testcontainersVersion = "1.17.6"

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 
     // testing
-    testImplementation("org.springframework.boot:spring-boot-autoconfigure:2.7.5")
+    testImplementation("org.springframework.boot:spring-boot-autoconfigure:3.0.0")
     testImplementation("org.springframework:spring-test:$springVersion")
     testImplementation("io.projectreactor:reactor-test:3.5.3")
     testImplementation(platform("org.junit:junit-bom:5.9.1"))

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     val springVersion = "5.3.23"
     val springDataVersion = "3.0.0"
     val kafkaVersion = "3.3.1"
-    val springKafkaVersion = "2.9.2"
+    val springKafkaVersion = "3.0.0"
     val testcontainersVersion = "1.17.6"
     val log4jVersion = "2.19.0"
 

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/repository/OutboxLockRepository.java
@@ -15,7 +15,7 @@
  */
 package one.tomorrow.transactionaloutbox.reactive.repository;
 
-import io.r2dbc.spi.Row;
+import io.r2dbc.spi.Readable;
 import lombok.RequiredArgsConstructor;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxLock;
 import org.slf4j.Logger;
@@ -125,7 +125,7 @@ public class OutboxLockRepository {
         return !ownerId.equals(lock.getOwnerId()) && lock.getValidUntil().isAfter(now());
     }
 
-    private OutboxLock toOutboxLock(Row row) {
+    private OutboxLock toOutboxLock(Readable row) {
         return new OutboxLock(row.get("owner_id", String.class), row.get("valid_until", Instant.class));
     }
 

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/KafkaTestSupport.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/KafkaTestSupport.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -127,7 +128,7 @@ public interface KafkaTestSupport {
     }
 
     default ConsumerRecords<String, byte[]> getAndCommitRecords(int minRecords) {
-        ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), 10_000, minRecords);
+        ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(10), minRecords);
         consumer().commitSync();
         return records;
     }

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/repository/OutboxRepositoryIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/repository/OutboxRepositoryIntegrationTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static one.tomorrow.transactionaloutbox.reactive.TestUtils.newRecord;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,7 +72,10 @@ class OutboxRepositoryIntegrationTest extends AbstractIntegrationTest {
         // then
         assertThat(result.size(), is(1));
         OutboxRecord foundRecord = result.get(0);
-        assertThat(foundRecord, samePropertyValuesAs(record2, "headers")); // ignore headers, because Json doesn't implement equals
+        // ignore created, because for the found record it's truncated to micros
+        // ignore headers, because Json doesn't implement equals
+        assertThat(foundRecord, samePropertyValuesAs(record2, "created", "headers"));
+        assertThat(foundRecord.getCreated().truncatedTo(MILLIS), is(equalTo(record2.getCreated().truncatedTo(MILLIS))));
         assertThat(foundRecord.getHeadersAsMap(), is(equalTo(record2.getHeadersAsMap())));
     }
 

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -8,7 +8,7 @@ java {
 }
 
 dependencies {
-    val springVersion = "5.3.23"
+    val springVersion = "6.0.2"
     val hibernateVersion = "5.6.14.Final"
     val kafkaVersion = "3.3.1"
     val springKafkaVersion = "3.0.0"

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     val springVersion = "5.3.23"
     val hibernateVersion = "5.6.14.Final"
     val kafkaVersion = "3.3.1"
-    val springKafkaVersion = "2.9.2"
+    val springKafkaVersion = "3.0.0"
     val log4jVersion = "2.19.0"
 
     implementation("org.springframework:spring-context:$springVersion")

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -20,8 +20,10 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 
     // testing
-    testImplementation("junit:junit:4.13.2")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.9.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+
     testImplementation("org.springframework:spring-test:$springVersion")
     testImplementation("org.testcontainers:postgresql:1.17.6")
     testImplementation("org.postgresql:postgresql:42.5.1")

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -1,7 +1,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    val springVersion = "6.0.7"
+    val springVersion = "6.0.8"
     val hibernateVersion = "6.2.1.Final"
     val kafkaVersion = "3.4.0"
     val springKafkaVersion = "3.0.5"

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -36,12 +36,3 @@ dependencies {
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
 }
-
-// conflict of vladmihalcea regarding jackson:
-//   Caused by: com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0
-// therefore we exclude the jackson-module-scala_2.12 pulled in by kafka to fix this
-configurations {
-    testImplementation {
-        exclude("com.fasterxml.jackson.module", "jackson-module-scala_2.12")
-    }
-}

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -1,12 +1,6 @@
 
 // the version is set in parent/root build.gradle.kts
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(14))
-    }
-}
-
 dependencies {
     val springVersion = "6.0.2"
     val hibernateVersion = "5.6.14.Final"

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -1,23 +1,20 @@
-
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
     val springVersion = "6.0.2"
-    val hibernateVersion = "5.6.14.Final"
+    val hibernateVersion = "6.2.1.Final"
     val kafkaVersion = "3.3.1"
     val springKafkaVersion = "3.0.0"
     val log4jVersion = "2.19.0"
 
     implementation("org.springframework:spring-context:$springVersion")
     implementation("org.springframework:spring-orm:$springVersion")
-    implementation("org.hibernate:hibernate-core-jakarta:$hibernateVersion")
-    implementation("org.hibernate:hibernate-java8:$hibernateVersion")
-    implementation("com.vladmihalcea:hibernate-types-55:2.20.0")
+    implementation("org.hibernate.orm:hibernate-core:$hibernateVersion")
+    implementation("com.vladmihalcea:hibernate-types-60:2.21.0")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
     implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:2.0.7")
-    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.1")
 
     // testing

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -10,14 +10,15 @@ dependencies {
 
     implementation("org.springframework:spring-context:$springVersion")
     implementation("org.springframework:spring-orm:$springVersion")
-    implementation("org.hibernate:hibernate-core:$hibernateVersion")
+    implementation("org.hibernate:hibernate-core-jakarta:$hibernateVersion")
     implementation("org.hibernate:hibernate-java8:$hibernateVersion")
-    implementation("com.vladmihalcea:hibernate-types-52:2.21.1")
+    implementation("com.vladmihalcea:hibernate-types-55:2.20.0")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
     implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:2.0.7")
-    implementation("javax.annotation:javax.annotation-api:1.3.2")
+    implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
+    implementation("jakarta.annotation:jakarta.annotation-api:2.1.1")
 
     // testing
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxLock.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxLock.java
@@ -19,10 +19,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.Instant;
 
 @Entity

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxRecord.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxRecord.java
@@ -21,12 +21,12 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Map;

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxRecord.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxRecord.java
@@ -19,7 +19,6 @@ import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,7 +32,6 @@ import java.util.Map;
 
 @Entity
 @Table(name = "outbox_kafka")
-@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -61,7 +59,7 @@ public class OutboxRecord {
     @Column(name = "value", nullable = false)
     private byte[] value;
 
-    @Type(type = "jsonb")
+    @Type(JsonBinaryType.class)
     @Column(name = "headers", columnDefinition = "jsonb")
     private Map<String, String> headers;
 

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.LockModeType;
+import jakarta.persistence.LockModeType;
 import java.time.Duration;
 import java.util.Optional;
 

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
@@ -54,8 +54,7 @@ public class OutboxLockRepository {
         // about invalid session/transaction state.
         Transaction tx = null;
         OutboxLock lock = null;
-        Session session = sessionFactory.openSession();
-        try {
+        try (Session session = sessionFactory.openSession()) {
             tx = session.beginTransaction();
 
             lock = session.get(OutboxLock.class, OutboxLock.OUTBOX_LOCK_ID);
@@ -64,7 +63,7 @@ public class OutboxLockRepository {
                 lock = new OutboxLock(ownerId, now().plus(timeout));
             } else if (ownerId.equals(lock.getOwnerId())) {
                 logger.debug("Found outbox lock with requested owner {}, valid until {} - updating lock", lock.getOwnerId(), lock.getValidUntil());
-                session.buildLockRequest(PESSIMISTIC_NOWAIT).lock(lock);
+                session.lock(lock, PESSIMISTIC_NOWAIT);
                 lock.setValidUntil(now().plus(timeout));
             } else if (!ownerId.equals(lock.getOwnerId()) && lock.getValidUntil().isAfter(now())) {
                 logger.debug("Found outbox lock with owner {}, valid until {}", lock.getOwnerId(), lock.getValidUntil());
@@ -72,7 +71,7 @@ public class OutboxLockRepository {
                 return false;
             } else {
                 logger.info("Found expired outbox lock with owner {}, which was valid until {} - grabbing lock for {}", lock.getOwnerId(), lock.getValidUntil(), ownerId);
-                session.buildLockRequest(PESSIMISTIC_NOWAIT).lock(lock);
+                session.lock(lock, PESSIMISTIC_NOWAIT);
                 lock.setOwnerId(ownerId);
                 lock.setValidUntil(now().plus(timeout));
             }
@@ -96,8 +95,6 @@ public class OutboxLockRepository {
                 tryRollback(tx);
                 throw e;
             }
-        } finally {
-            session.close();
         }
     }
 
@@ -143,7 +140,7 @@ public class OutboxLockRepository {
         queryByOwnerId(session, ownerId)
                 .uniqueResultOptional()
                 .ifPresentOrElse(lock -> {
-                            session.delete(lock);
+                            session.remove(lock);
                             session.flush();
                             logger.info("Released outbox lock for owner {}", ownerId);
                         },

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
@@ -84,6 +84,8 @@ public class OutboxLockRepository {
             return true;
         } catch (LockingStrategyException e) {
             return handleException(e, ownerId, lock, tx);
+        } catch (ConstraintViolationException e) {
+            return handleException(e, ownerId, tx);
         } catch (Throwable e) {
             if (e.getCause() instanceof ConstraintViolationException)
                 return handleException((ConstraintViolationException) e.getCause(), ownerId, tx);

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
@@ -34,7 +34,7 @@ public class OutboxRepository {
 
     @Transactional
     public void update(OutboxRecord record) {
-        sessionFactory.getCurrentSession().update(record);
+        sessionFactory.getCurrentSession().merge(record);
     }
 
     /**

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/ConcurrentOutboxProcessorsIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/ConcurrentOutboxProcessorsIntegrationTest.java
@@ -126,7 +126,7 @@ public class ConcurrentOutboxProcessorsIntegrationTest {
         // then
         List<ConsumerRecord<String, byte[]>> allRecords = new ArrayList<>();
         while(allRecords.size() < outboxRecords.size()) {
-            ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), 5_000);
+            ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(5));
             records.iterator().forEachRemaining(allRecords::add);
         }
 

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
@@ -139,7 +139,7 @@ public class OutboxProcessorIntegrationTest {
     }
 
     private ConsumerRecords<String, byte[]> getAndCommitRecords() {
-        ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), 10_000);
+        ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(10));
         consumer().commitSync();
         return records;
     }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxUsageIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxUsageIntegrationTest.java
@@ -119,7 +119,7 @@ public class OutboxUsageIntegrationTest {
         sampleService.doSomething(id, name);
 
         // then
-        ConsumerRecords<String, Message> records = KafkaTestUtils.getRecords(consumer(), 5_000);
+        ConsumerRecords<String, Message> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(5));
         assertThat(records.count(), is(1));
         ConsumerRecord<String, Message> kafkaRecord = records.iterator().next();
         assertTrue(kafkaRecord.value() instanceof SomethingHappened);
@@ -139,7 +139,7 @@ public class OutboxUsageIntegrationTest {
         sampleService.doSomethingWithAdditionalHeaders(id, name, additionalHeader);
 
         // then
-        ConsumerRecords<String, Message> records = KafkaTestUtils.getRecords(consumer(), 5_000);
+        ConsumerRecords<String, Message> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(5));
         assertThat(records.count(), is(1));
         ConsumerRecord<String, Message> kafkaRecord = records.iterator().next();
         assertTrue(kafkaRecord.value() instanceof SomethingHappened);


### PR DESCRIPTION
Merged various PRs mentioned in #56 plus necessary adjustments.

The versions of classic/reactive modules are pushed to the next major (SNAPSHOT) version to show users that this is *not* a drop-in replacement.

Resolves #56 