### PR TITLE
Fix version badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![ci](https://github.com/tomorrow-one/transactional-outbox/actions/workflows/gradle-build.yml/badge.svg)](https://github.com/tomorrow-one/transactional-outbox/actions/workflows/gradle-build.yml)
-[![maven: outbox-kafka-spring](https://img.shields.io/maven-central/v/one.tomorrow.transactional-outbox/outbox-kafka-spring.svg?label=maven:%20outbox-kafka-spring)](https://search.maven.org/search?q=g:%22one.tomorrow.transactional-outbox%22%20AND%20a:%22outbox-kafka-spring%22)
-[![maven: outbox-kafka-spring-reactive](https://img.shields.io/maven-central/v/one.tomorrow.transactional-outbox/outbox-kafka-spring-reactive.svg?label=maven:%20outbox-kafka-spring-reactive)](https://search.maven.org/search?q=g:%22one.tomorrow.transactional-outbox%22%20AND%20a:%22outbox-kafka-spring-reactive%22)
+[![maven: outbox-kafka-spring](https://img.shields.io/maven-central/v/one.tomorrow.transactional-outbox/outbox-kafka-spring.svg?label=maven:%20outbox-kafka-spring)](https://central.sonatype.com/search?q=pkg%253Amaven%252Fone.tomorrow.transactional-outbox%252Foutbox-kafka-spring)
+[![maven: outbox-kafka-spring-reactive](https://img.shields.io/maven-central/v/one.tomorrow.transactional-outbox/outbox-kafka-spring-reactive.svg?label=maven:%20outbox-kafka-spring-reactive)](https://central.sonatype.com/search?q=pkg%253Amaven%252Fone.tomorrow.transactional-outbox%252Foutbox-kafka-spring-reactive)
 
 # Transactional Outbox
 


### PR DESCRIPTION
The search.maven.org got changed to central.sonatype.com, see also [this FAQ on central.sonatype.org](https://central.sonatype.org/faq/what-happened-to-search-maven-org/).