### PR TITLE
101 align license header year

### DIFF
--- a/LICENSE-header.txt
+++ b/LICENSE-header.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Tomorrow GmbH @ https://tomorrow.one
+Copyright ${year} Tomorrow GmbH @ https://tomorrow.one
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
+import java.util.*
 
 project(":commons").version = "2.0.0-SNAPSHOT"
 project(":outbox-kafka-spring").version = "2.0.0-SNAPSHOT"
@@ -53,6 +54,8 @@ subprojects {
                 "one/tomorrow/transactionaloutbox/reactive/test/Sample.java"
         )) // java sources generated from proto messages
         include("**/*.java")
+        ext["year"] = Calendar.getInstance().get(Calendar.YEAR)
+        skipExistingHeaders = true
     }
 
     val subproject = this

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxRecord.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/model/OutboxRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Tomorrow GmbH @ https://tomorrow.one
+ * Copyright 2022-2023 Tomorrow GmbH @ https://tomorrow.one
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Tomorrow GmbH @ https://tomorrow.one
+ * Copyright 2022-2023 Tomorrow GmbH @ https://tomorrow.one
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Tomorrow GmbH @ https://tomorrow.one
+ * Copyright 2022-2023 Tomorrow GmbH @ https://tomorrow.one
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/update_copyright_headers.sh
+++ b/update_copyright_headers.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Shell script that can be used to update copyright headers
+# for files that have been updated during this year
+# determined by the git diff command.
+
+year=$(date +'%Y')
+
+echo "Updating copyright headers for all java files that have been changed in $year"
+# Changed in the specified year and committed
+for file in $(git log --pretty='%aI %H' \
+    |awk -v year="$year" '$1 >= year"-01-01" && $1 <= year"-12-31" { print $2 }' | git --no-pager log --no-walk --name-only --stdin | grep -E "^.+\.(java)$"| sort | uniq ); do
+  echo "Updating file $file"
+	sed -i "" "s/Copyright \([0-9]\{4\}\)\(-[0-9]\{4\}\)\{0,1\} Tomorrow GmbH/Copyright \1-$year Tomorrow GmbH/g" "$file";
+done


### PR DESCRIPTION
As discussed in #101 we think it makes sense to append the last change to the license headers if the files changed in a year. As this is not possible to do integrated in our license plugin the proposal was to disable it for existing files and change them manually.

To support the manual maintenance of the copyrights there is now a little helper script that extends copyright headers to the current year if needed (depending on the git logs)