### PR TITLE
Set `enable.idempotence = true` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The application stores the serialized message that shall be published (to a cert
 The library continuously processes the outbox and publishes the serialized message together with some headers
 to the specified topic. Messages are published with the following guarantees:
 * *strict ordering*: i.e. messages are published in the order
-they're stored in the outbox. In consequence, if a message could not be published, it will not try to publish the next message. *Note*: for this the kafka producer must have set `max.in.flight.requests.per.connection = 1`, which is set automatically in the default setup as shown below.
-* *at-least-once delivery*: every message from the outbox is published at least once, i.e. in case of errors (e.g. database unavailability or network errors) there may be duplicates. Consumers are responsible for deduplication.
+they're stored in the outbox. *Note*: for this the kafka producer should have set `enable.idempotence = true` to enforce valid related settings according to [enable.idempotence docs](https://kafka.apache.org/documentation/#producerconfigs_enable.idempotence) (which is set automatically in the default setup as shown below). If you need different/custom settings you probably know what you're doing, and consciously choose appropriate settings of e.g. `max.in.flight.requests.per.connection`, `retries` and `acks`.
+* *at-least-once delivery*: every message from the outbox is published at least once, i.e. in case of errors (e.g. database unavailability or network errors or process crashes/restarts) there may be duplicates. Consumers are responsible for deduplication.
 
 Messages are published with the headers `x-value-type`, `x-sequence` and `x-source`:
 * `x-value-type` is set to the fully-qualified name of the protobuf message (within the proto language's namespace).
@@ -107,9 +107,11 @@ per instance).
 
 The `OutboxProcessor` is the component which processes the outbox and publishes messages/events to Kafka, once it could
  obtain the lock. If it could not obtain the lock on startup, it will continuously monitor the lock and try to obtain
- it (in case the lock-holding instance crashed or could not longer refresh the lock).
+ it (in case the lock-holding instance crashed or could no longer refresh the lock).
 
-*Note*: so that messages are published in-order as expected, the producer must be configured with `max.in.flight.requests.per.connection = 1`. If you're using the `DefaultKafkaProducerFactory` as shown below, the provided `producerProps` should either have *not* set `max.in.flight.requests.per.connection` (then it would be set by `DefaultKafkaProducerFactory`) or it must be set to `1`.
+*Note*: so that messages are published in-order as expected, the producer must be configured with
+`enable.idempotence = true` (to enforce valid related settings according to [enable.idempotence docs](https://kafka.apache.org/documentation/#producerconfigs_enable.idempotence)) or - if you have reasons to not use `enable.idempotence = true` - appropriate settings of at least `max.in.flight.requests.per.connection`, `retries` and `acks`.
+If you're using the `DefaultKafkaProducerFactory` as shown below, it will set `enable.idempotence = true` if the provided `producerProps` do not have set `enable.idempotence` already.
 
 #### Setup the `OutboxProcessor` from `outbox-kafka-spring` (classic projects)
 

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/DefaultKafkaProducerFactory.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/DefaultKafkaProducerFactory.java
@@ -19,6 +19,8 @@ import one.tomorrow.transactionaloutbox.reactive.service.OutboxProcessor.KafkaPr
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,18 +29,19 @@ import static org.apache.kafka.clients.producer.ProducerConfig.*;
 
 public class DefaultKafkaProducerFactory implements KafkaProducerFactory {
 
+	private static final Logger logger = LoggerFactory.getLogger(DefaultKafkaProducerFactory.class);
+
 	private final HashMap<String, Object> producerProps;
 
 	public DefaultKafkaProducerFactory(Map<String, Object> producerProps) {
 		HashMap<String, Object> props = new HashMap<>(producerProps);
-		// Settings for dealing with broker failures - so that the producer.send returned future eventually fails
-		// due to a timeoutexception and we can recreate it.
-		// For preventing out-of-order messages in case of broker failures and internal producer retries, usually
-		// the first 2 properties should be set to Int.MAX / Long.MAX - which we do not need so far because we're
-		// sending record by record, without batching.
-		setIfNotSet(props, RETRIES_CONFIG, 10);
-		setIfNotSet(props, MAX_BLOCK_MS_CONFIG, 1000);
-		setIfNotSet(props, MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+		// Settings for guaranteed ordering (via enable.idempotence) and dealing with broker failures.
+		// Note that with `enable.idempotence = true` ordering of messages is also checked by the broker.
+		if (Boolean.FALSE.equals(props.get(ENABLE_IDEMPOTENCE_CONFIG)))
+			logger.warn(ENABLE_IDEMPOTENCE_CONFIG + " is set to 'false' - this might lead to out-of-order messages.");
+
+		setIfNotSet(props, ENABLE_IDEMPOTENCE_CONFIG, true);
+
 		// serializer settings
 		props.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 		props.put(VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);


### PR DESCRIPTION
And rely on defaults for related properties `max.in.flight.requests.per.connection`, `retries` and `acks`.

If the user has configured `enable.idempotence = false` a warning is logged - assuming that the user probably knows what she's doing.

The motivation was discussed in #39: with `enable.idempotence = true` out-of-order messages are prevented for the active producer (the sequence check on server side checks if `nextSeq == lastSeq + 1L` - so that missing messages are detected). With `enable.idempotence` we can use the default `max.in.flight.requests.per.connection = 5` to get increased throughput.

Closes #39 