### PR TITLE
Optimize outbox processing to enable producer batching

### DIFF
--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+    testImplementation("org.mockito:mockito-all:1.8.4")
 
     testImplementation("org.springframework:spring-test:$springVersion")
     testImplementation("org.testcontainers:postgresql:1.17.6")

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -21,7 +21,6 @@ import one.tomorrow.transactionaloutbox.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.repository.OutboxRepository;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -29,7 +28,6 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -165,15 +163,30 @@ public class OutboxProcessor {
 
 	}
 
-	private void processOutbox() throws ExecutionException, InterruptedException {
-		List<OutboxRecord> records = repository.getUnprocessedRecords(BATCH_SIZE);
-		for (OutboxRecord outboxRecord : records) {
-			ProducerRecord<String, byte[]> producerRecord = toProducerRecord(outboxRecord);
-			Future<RecordMetadata> result = producer.send(producerRecord);
-			result.get();
-			logger.info("Sent record to kafka: {}", outboxRecord);
-			outboxRecord.setProcessed(now());
-			repository.update(outboxRecord);
+	private void processOutbox() {
+		repository.getUnprocessedRecords(BATCH_SIZE)
+				.stream()
+				.map(outboxRecord -> producer.send(toProducerRecord(outboxRecord), (metadata, exception) -> {
+					if (exception != null) {
+						logger.warn("Failed to publish {}", outboxRecord, exception);
+					} else {
+						logger.info("Sent record to kafka: {}", outboxRecord);
+						outboxRecord.setProcessed(now());
+						repository.update(outboxRecord);
+					}
+				}))
+				.toList() // collect to List (so that map is completed for all items before awaiting futures), to use producer internal batching
+				.forEach(OutboxProcessor::await);
+	}
+
+	private static void await(Future<?> future) {
+		try {
+			future.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		} catch (ExecutionException e) {
+			throw new RuntimeException(e);
 		}
 	}
 
@@ -190,6 +203,5 @@ public class OutboxProcessor {
 		producerRecord.headers().add(HEADERS_SOURCE_NAME, eventSource);
 		return producerRecord;
 	}
-
 
 }

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -163,7 +163,7 @@ public class OutboxProcessor {
 
 	}
 
-	private void processOutbox() {
+	void processOutbox() {
 		repository.getUnprocessedRecords(BATCH_SIZE)
 				.stream()
 				.map(outboxRecord -> producer.send(toProducerRecord(outboxRecord), (metadata, exception) -> {

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.service;
+
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import one.tomorrow.transactionaloutbox.repository.OutboxRepository;
+import one.tomorrow.transactionaloutbox.service.OutboxProcessor.KafkaProducerFactory;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+public class OutboxProcessorTest {
+
+    private final OutboxRepository repository = mock(OutboxRepository.class);
+
+    private final KafkaProducerFactory producerFactory = mock(KafkaProducerFactory.class);
+
+    private final AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+
+    private final KafkaProducer<String, byte[]> producer = mock(KafkaProducer.class);
+
+    private final OutboxRecord record1 = mock(OutboxRecord.class, RETURNS_MOCKS);
+    private final OutboxRecord record2 = mock(OutboxRecord.class, RETURNS_MOCKS);
+    private final List<OutboxRecord> records = List.of(record1, record2);
+
+    private final Future<RecordMetadata> future1 = mock(Future.class);
+    private final Future<RecordMetadata> future2 = mock(Future.class);
+
+    private OutboxProcessor processor;
+
+    @Before
+    public void setup() {
+        when(producerFactory.createKafkaProducer()).thenReturn(producer);
+
+        OutboxLockService lockService = mock(OutboxLockService.class);
+        when(lockService.getLockTimeout()).thenReturn(Duration.ZERO);
+        when(beanFactory.applyBeanPostProcessorsAfterInitialization(any(), anyString())).thenReturn(lockService);
+
+        processor = new OutboxProcessor(
+                repository,
+                producerFactory,
+                Duration.ZERO,
+                Duration.ZERO,
+                "lockOwnerId",
+                "eventSource",
+                beanFactory);
+
+        when(record1.getKey()).thenReturn("r1");
+        when(record2.getKey()).thenReturn("r2");
+    }
+
+    /* Verifies, that all items are submitted to producer.send before the first future.get() is invoked */
+    @Test
+    public void processOutboxShouldUseProducerInternalBatching() throws ExecutionException, InterruptedException {
+        when(repository.getUnprocessedRecords(anyInt())).thenReturn(records);
+
+        AtomicInteger sendCounter = new AtomicInteger(0);
+
+        when(producer.send(argThat(matching(record1)), any())).thenAnswer(invocation -> {
+            sendCounter.incrementAndGet();
+            sleep(10);
+            return future1;
+        });
+        when(producer.send(argThat(matching(record2)), any())).thenAnswer(invocation -> {
+            sendCounter.incrementAndGet();
+            sleep(10);
+            return future2;
+        });
+
+        when(future1.get()).thenAnswer(invocation -> {
+            assertEquals(2, sendCounter.get());
+            return null;
+        });
+
+        when(future2.get()).thenAnswer(invocation -> {
+            assertEquals(2, sendCounter.get());
+            return null;
+        });
+
+        processor.processOutbox();
+    }
+
+    @Test
+    public void processOutboxShouldSetProcessedOnlyOnSuccess() {
+        when(repository.getUnprocessedRecords(anyInt())).thenReturn(records);
+
+        RecordMetadata metadata = new RecordMetadata(new TopicPartition("t", -1), -1, -1, -1, -1, -1);
+
+        when(producer.send(argThat(matching(record1)), any())).thenAnswer(invocation -> {
+            Callback callback = (Callback) invocation.getArguments()[1];
+            callback.onCompletion(metadata, new RuntimeException("simulated exception"));
+            return future1;
+        });
+        when(producer.send(argThat(matching(record2)), any())).thenAnswer(invocation -> {
+            Callback callback = (Callback) invocation.getArguments()[1];
+            callback.onCompletion(metadata, null);
+            return future2;
+        });
+
+        processor.processOutbox();
+
+        verify(record1, never()).setProcessed(any());
+        verify(repository, never()).update(record1);
+
+        verify(record2).setProcessed(any());
+        verify(repository).update(record2);
+    }
+
+    @NotNull
+    private static Matcher<ProducerRecord<String, byte[]>> matching(OutboxRecord record) {
+        return new BaseMatcher<>() {
+            @Override
+            public void describeTo(Description description) {
+            }
+
+            @Override
+            public boolean matches(Object item) {
+                if (item == null)
+                    return false;
+                return Objects.equals(((ProducerRecord<String, byte[]>) item).key(), record.getKey());
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
This was an insight in the context of issue #39: the classic module processed outbox records sequentially, awaiting the successful publishing of one record, updating its `processed` property, and only then processing the next record.

This made producer internal batching impossible and reduces the throughput. For low traffic environments this might not make a difference, but with more traffic this might become an issue and limit throughput too much.

Especially with PR #134, with `idempotence = true` set by the `DefaultKafkaProducerFactory`, the
`max.in.flight.requests.per.connection` would be 5 (which was set to 1 before), which also allows more throughput even on a single partition.