### PR TITLE
Prevent broken outbox processor due to db connection issues

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Validate gradle wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Build
-      uses: gradle/gradle-build-action@v2.4.2
+      uses: gradle/gradle-build-action@v2.7.1
       with:
         arguments: build
 
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Publish
-        uses: gradle/gradle-build-action@v2.4.2
+        uses: gradle/gradle-build-action@v2.7.1
         env:
           # variables used by build.gradle.kts for signing / publishing (without 'ORG_GRADLE_PROJECT_' prefix)
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       uses: gradle/gradle-build-action@v2.7.1
       with:
-        arguments: build
+        arguments: build -Porg.gradle.jvmargs=-Xmx2048m
 
   publish:
     needs: [ build ]

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     val kafkaVersion = "3.5.1"
     val springKafkaVersion = "3.0.9"
     val log4jVersion = "2.20.0"
+    val testcontainersVersion = "1.18.3"
 
     implementation("org.springframework:spring-context:$springVersion")
     implementation("org.springframework:spring-orm:$springVersion")
@@ -24,7 +25,8 @@ dependencies {
     testImplementation("org.mockito:mockito-all:1.10.19")
 
     testImplementation("org.springframework:spring-test:$springVersion")
-    testImplementation("org.testcontainers:postgresql:1.18.3")
+    testImplementation("org.testcontainers:postgresql:$testcontainersVersion")
+    testImplementation("org.testcontainers:toxiproxy:$testcontainersVersion")
     testImplementation("org.postgresql:postgresql:42.6.0")
     testImplementation("org.flywaydb:flyway-core:9.21.2")
     testImplementation("org.flywaydb.flyway-test-extensions:flyway-spring-test:9.5.0")

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -41,108 +41,108 @@ import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SOUR
 
 public class OutboxProcessor {
 
-	@FunctionalInterface
-	public interface KafkaProducerFactory {
-		KafkaProducer<String, byte[]> createKafkaProducer();
-	}
+    @FunctionalInterface
+    public interface KafkaProducerFactory {
+        KafkaProducer<String, byte[]> createKafkaProducer();
+    }
 
-	private static final int BATCH_SIZE = 100;
+    private static final int BATCH_SIZE = 100;
 
-	private static final Logger logger = LoggerFactory.getLogger(OutboxProcessor.class);
+    private static final Logger logger = LoggerFactory.getLogger(OutboxProcessor.class);
 
-	private final OutboxLockService lockService;
-	private final String lockOwnerId;
-	private final OutboxRepository repository;
-	private final KafkaProducerFactory producerFactory;
-	private final Duration processingInterval;
-	private final ScheduledExecutorService executor;
-	private final byte[] eventSource;
-	private KafkaProducer<String, byte[]> producer;
-	private boolean active;
-	private Instant lastLockAckquisitionAttempt;
+    private final OutboxLockService lockService;
+    private final String lockOwnerId;
+    private final OutboxRepository repository;
+    private final KafkaProducerFactory producerFactory;
+    private final Duration processingInterval;
+    private final ScheduledExecutorService executor;
+    private final byte[] eventSource;
+    private KafkaProducer<String, byte[]> producer;
+    private boolean active;
+    private Instant lastLockAckquisitionAttempt;
 
-	private ScheduledFuture<?> schedule;
+    private ScheduledFuture<?> schedule;
 
-	public OutboxProcessor(
-			OutboxRepository repository,
-			KafkaProducerFactory producerFactory,
-			Duration processingInterval,
-			Duration lockTimeout,
-			String lockOwnerId,
-			String eventSource,
-			AutowireCapableBeanFactory beanFactory) {
-		logger.info("Starting outbox processor with lockOwnerId {}, source {} and processing interval {} ms and producer factory {}",
-				lockOwnerId, eventSource, processingInterval.toMillis(), producerFactory);
-		this.repository = repository;
-		this.processingInterval = processingInterval;
-		OutboxLockRepository lockRepository = beanFactory.getBean(OutboxLockRepository.class);
-		OutboxLockService rawLockService = new OutboxLockService(lockRepository, lockTimeout);
-		this.lockService = (OutboxLockService) beanFactory.applyBeanPostProcessorsAfterInitialization(rawLockService, "OutboxLockService");
-		this.lockOwnerId = lockOwnerId;
-		this.eventSource = eventSource.getBytes();
-		this.producerFactory = producerFactory;
-		producer = producerFactory.createKafkaProducer();
+    public OutboxProcessor(
+            OutboxRepository repository,
+            KafkaProducerFactory producerFactory,
+            Duration processingInterval,
+            Duration lockTimeout,
+            String lockOwnerId,
+            String eventSource,
+            AutowireCapableBeanFactory beanFactory) {
+        logger.info("Starting outbox processor with lockOwnerId {}, source {} and processing interval {} ms and producer factory {}",
+                lockOwnerId, eventSource, processingInterval.toMillis(), producerFactory);
+        this.repository = repository;
+        this.processingInterval = processingInterval;
+        OutboxLockRepository lockRepository = beanFactory.getBean(OutboxLockRepository.class);
+        OutboxLockService rawLockService = new OutboxLockService(lockRepository, lockTimeout);
+        this.lockService = (OutboxLockService) beanFactory.applyBeanPostProcessorsAfterInitialization(rawLockService, "OutboxLockService");
+        this.lockOwnerId = lockOwnerId;
+        this.eventSource = eventSource.getBytes();
+        this.producerFactory = producerFactory;
+        producer = producerFactory.createKafkaProducer();
 
-		executor = Executors.newSingleThreadScheduledExecutor();
+        executor = Executors.newSingleThreadScheduledExecutor();
 
-		tryLockAcquisition();
-	}
+        tryLockAcquisition();
+    }
 
-	private void scheduleProcessing() {
-		if (executor.isShutdown())
-			logger.info("Not scheduling processing for lockOwnerId {} (executor is shutdown)", lockOwnerId);
-		else
-			schedule = executor.schedule(this::processOutboxWithLock, processingInterval.toMillis(), MILLISECONDS);
-	}
+    private void scheduleProcessing() {
+        if (executor.isShutdown())
+            logger.info("Not scheduling processing for lockOwnerId {} (executor is shutdown)", lockOwnerId);
+        else
+            schedule = executor.schedule(this::processOutboxWithLock, processingInterval.toMillis(), MILLISECONDS);
+    }
 
-	private void scheduleTryLockAcquisition() {
-		if (executor.isShutdown())
-			logger.info("Not scheduling acquisition of outbox lock for lockOwnerId {} (executor is shutdown)", lockOwnerId);
-		else
-			schedule = executor.schedule(this::tryLockAcquisition, lockService.getLockTimeout().toMillis(), MILLISECONDS);
-	}
+    private void scheduleTryLockAcquisition() {
+        if (executor.isShutdown())
+            logger.info("Not scheduling acquisition of outbox lock for lockOwnerId {} (executor is shutdown)", lockOwnerId);
+        else
+            schedule = executor.schedule(this::tryLockAcquisition, lockService.getLockTimeout().toMillis(), MILLISECONDS);
+    }
 
-	@PreDestroy
-	public void close() {
-		logger.info("Stopping OutboxProcessor.");
-		if (schedule != null)
-			schedule.cancel(false);
-		executor.shutdown();
-		producer.close();
-		if (active)
-			lockService.releaseLock(lockOwnerId);
-	}
+    @PreDestroy
+    public void close() {
+        logger.info("Stopping OutboxProcessor.");
+        if (schedule != null)
+            schedule.cancel(false);
+        executor.shutdown();
+        producer.close();
+        if (active)
+            lockService.releaseLock(lockOwnerId);
+    }
 
-	private void tryLockAcquisition() {
-		try {
-			boolean originalActive = active;
-			logger.debug("{} trying to acquire outbox lock", lockOwnerId);
-			active = lockService.acquireOrRefreshLock(lockOwnerId);
-			lastLockAckquisitionAttempt = now();
-			if (active) {
-				if (originalActive)
-					logger.debug("{} acquired outbox lock, starting to process outbox", lockOwnerId);
-				else
-					logger.info("{} acquired outbox lock, starting to process outbox", lockOwnerId);
+    private void tryLockAcquisition() {
+        try {
+            boolean originalActive = active;
+            logger.debug("{} trying to acquire outbox lock", lockOwnerId);
+            active = lockService.acquireOrRefreshLock(lockOwnerId);
+            lastLockAckquisitionAttempt = now();
+            if (active) {
+                if (originalActive)
+                    logger.debug("{} acquired outbox lock, starting to process outbox", lockOwnerId);
+                else
+                    logger.info("{} acquired outbox lock, starting to process outbox", lockOwnerId);
 
-				processOutboxWithLock();
-			}
-			else
-				scheduleTryLockAcquisition();
-		} catch (Exception e) {
-			logger.warn("Failed trying lock acquisition or processing the outbox, trying again in {}", lockService.getLockTimeout(), e);
-			scheduleTryLockAcquisition();
-		}
-	}
+                processOutboxWithLock();
+            }
+            else
+                scheduleTryLockAcquisition();
+        } catch (Exception e) {
+            logger.warn("Failed trying lock acquisition or processing the outbox, trying again in {}", lockService.getLockTimeout(), e);
+            scheduleTryLockAcquisition();
+        }
+    }
 
-	private void processOutboxWithLock() {
-		if (!active)
-			throw new IllegalStateException("processOutbox must only be run when in active state");
+    private void processOutboxWithLock() {
+        if (!active)
+            throw new IllegalStateException("processOutbox must only be run when in active state");
 
-		if (now().isAfter(lastLockAckquisitionAttempt.plus(lockService.getLockTimeout().dividedBy(2)))) {
-			tryLockAcquisition();
-			return;
-		}
+        if (now().isAfter(lastLockAckquisitionAttempt.plus(lockService.getLockTimeout().dividedBy(2)))) {
+            tryLockAcquisition();
+            return;
+        }
 
         boolean couldRunWithLock = tryProcessOutbox();
         if (couldRunWithLock) {
@@ -173,45 +173,45 @@ public class OutboxProcessor {
         return couldRunWithLock;
     }
 
-	void processOutbox() {
-		repository.getUnprocessedRecords(BATCH_SIZE)
-				.stream()
-				.map(outboxRecord -> producer.send(toProducerRecord(outboxRecord), (metadata, exception) -> {
-					if (exception != null) {
-						logger.warn("Failed to publish {}", outboxRecord, exception);
-					} else {
-						logger.info("Sent record to kafka: {}", outboxRecord);
-						outboxRecord.setProcessed(now());
-						repository.update(outboxRecord);
-					}
-				}))
-				.toList() // collect to List (so that map is completed for all items before awaiting futures), to use producer internal batching
-				.forEach(OutboxProcessor::await);
-	}
+    void processOutbox() {
+        repository.getUnprocessedRecords(BATCH_SIZE)
+                .stream()
+                .map(outboxRecord -> producer.send(toProducerRecord(outboxRecord), (metadata, exception) -> {
+                    if (exception != null) {
+                        logger.warn("Failed to publish {}", outboxRecord, exception);
+                    } else {
+                        logger.info("Sent record to kafka: {}", outboxRecord);
+                        outboxRecord.setProcessed(now());
+                        repository.update(outboxRecord);
+                    }
+                }))
+                .toList() // collect to List (so that map is completed for all items before awaiting futures), to use producer internal batching
+                .forEach(OutboxProcessor::await);
+    }
 
-	private static void await(Future<?> future) {
-		try {
-			future.get();
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new RuntimeException(e);
-		} catch (ExecutionException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    private static void await(Future<?> future) {
+        try {
+            future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	private ProducerRecord<String, byte[]> toProducerRecord(OutboxRecord outboxRecord) {
-		ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(
-				outboxRecord.getTopic(),
-				outboxRecord.getKey(),
-				outboxRecord.getValue()
-		);
-		if (outboxRecord.getHeaders() != null) {
-			outboxRecord.getHeaders().forEach((k, v) -> producerRecord.headers().add(k, v.getBytes()));
-		}
-		producerRecord.headers().add(HEADERS_SEQUENCE_NAME, Longs.toByteArray(outboxRecord.getId()));
-		producerRecord.headers().add(HEADERS_SOURCE_NAME, eventSource);
-		return producerRecord;
-	}
+    private ProducerRecord<String, byte[]> toProducerRecord(OutboxRecord outboxRecord) {
+        ProducerRecord<String, byte[]> producerRecord = new ProducerRecord<>(
+                outboxRecord.getTopic(),
+                outboxRecord.getKey(),
+                outboxRecord.getValue()
+        );
+        if (outboxRecord.getHeaders() != null) {
+            outboxRecord.getHeaders().forEach((k, v) -> producerRecord.headers().add(k, v.getBytes()));
+        }
+        producerRecord.headers().add(HEADERS_SEQUENCE_NAME, Longs.toByteArray(outboxRecord.getId()));
+        producerRecord.headers().add(HEADERS_SOURCE_NAME, eventSource);
+        return producerRecord;
+    }
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/IntegrationTestConfig.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/IntegrationTestConfig.java
@@ -36,13 +36,16 @@ import java.util.Properties;
 public class IntegrationTestConfig {
 
     public static final Duration DEFAULT_OUTBOX_LOCK_TIMEOUT = Duration.ofMillis(200);
+    public static ProxiedPostgreSQLContainer postgresqlContainer = ProxiedPostgreSQLContainer.startProxiedPostgres();
 
     @Bean
     public DataSource dataSource() {
         BasicDataSource dataSource = new BasicDataSource();
 
-        dataSource.setDriverClassName("org.testcontainers.jdbc.ContainerDatabaseDriver");
-        dataSource.setUrl("jdbc:tc:postgresql:13.7://localhost/test");
+        dataSource.setDriverClassName(postgresqlContainer.getDriverClassName());
+        dataSource.setUrl(postgresqlContainer.getJdbcUrl());
+        dataSource.setUsername(postgresqlContainer.getUsername());
+        dataSource.setPassword(postgresqlContainer.getPassword());
 
         return dataSource;
     }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/ProxiedPostgreSQLContainer.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/ProxiedPostgreSQLContainer.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox;
+
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class ProxiedPostgreSQLContainer extends PostgreSQLContainer<ProxiedPostgreSQLContainer> {
+
+    private static ProxiedPostgreSQLContainer postgres;
+    public static ToxiproxyContainer toxiproxy;
+    public static ToxiproxyContainer.ContainerProxy postgresProxy;
+    private static String jdbcUrl;
+
+    public ProxiedPostgreSQLContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+
+    public static ProxiedPostgreSQLContainer startProxiedPostgres() {
+        if (postgres == null) {
+            int exposedPostgresPort = POSTGRESQL_PORT;
+
+            Network network = Network.newNetwork();
+
+            postgres = new ProxiedPostgreSQLContainer(DockerImageName.parse("postgres:13.7"))
+                    .withExposedPorts(exposedPostgresPort)
+                    .withNetwork(network);
+
+            toxiproxy = new ToxiproxyContainer(DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.5.0"))
+                    .withNetwork(network);
+
+            toxiproxy.start();
+            postgresProxy = toxiproxy.getProxy(postgres, exposedPostgresPort);
+
+            jdbcUrl = "jdbc:postgresql://" + postgresProxy.getContainerIpAddress() +
+                    ":" + postgresProxy.getProxyPort() + "/" + postgres.getDatabaseName();
+
+            postgres.start();
+        }
+        return postgres;
+    }
+
+    public static void stopProxiedPostgres() {
+        if (toxiproxy != null)
+            toxiproxy.stop();
+        if (postgres != null)
+            postgres.stop();
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return jdbcUrl;
+    }
+
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package one.tomorrow.transactionaloutbox.service;
 
+import eu.rekawek.toxiproxy.model.toxic.Timeout;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import kafka.server.KafkaConfig$;
@@ -49,12 +50,15 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static eu.rekawek.toxiproxy.model.ToxicDirection.DOWNSTREAM;
 import static one.tomorrow.transactionaloutbox.IntegrationTestConfig.DEFAULT_OUTBOX_LOCK_TIMEOUT;
+import static one.tomorrow.transactionaloutbox.ProxiedPostgreSQLContainer.postgresProxy;
 import static one.tomorrow.transactionaloutbox.TestUtils.newHeaders;
 import static one.tomorrow.transactionaloutbox.TestUtils.newRecord;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SEQUENCE_NAME;
@@ -190,6 +194,37 @@ public class OutboxProcessorIntegrationTest {
         // then
         records = getAndCommitRecords();
         assertThat(records.count(), is(1));
+        assertConsumedRecord(record2, "h2", eventSource, records.iterator().next());
+    }
+
+    @Test
+    public void should_ContinueProcessingAfterDatabaseUnavailability() throws InterruptedException, IOException {
+        // given
+        OutboxRecord record1 = newRecord(topic1, "key1", "value1", newHeaders("h1", "v1"));
+        transactionalRepository.persist(record1);
+
+        Duration processingInterval = Duration.ofMillis(50);
+        Duration outboxLockTimeout = Duration.ofMillis(500);
+        String eventSource = "test";
+        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, outboxLockTimeout, "processor", eventSource, beanFactory);
+
+        // when
+        ConsumerRecords<String, byte[]> records = getAndCommitRecords();
+
+        // then
+        assertEquals(1, records.count());
+
+        // and when
+        Timeout timeout = postgresProxy.toxics().timeout("TIMEOUT", DOWNSTREAM, 1L);
+        Thread.sleep(processingInterval.multipliedBy(5).toMillis());
+        timeout.remove();
+
+        OutboxRecord record2 = newRecord(topic2, "key2", "value2", newHeaders("h2", "v2"));
+        transactionalRepository.persist(record2);
+
+        // then
+        records = getAndCommitRecords();
+        assertEquals(1, records.count());
         assertConsumedRecord(record2, "h2", eventSource, records.iterator().next());
     }
 


### PR DESCRIPTION
This was reported via https://github.com/tomorrow-one/transactional-outbox/discussions/135

The issue could be reproduced with a test, simulating db connection issues. The problem was, that the exception thrown by `lockService.runWithLock` wasn't caught so that the schedule got broken, i.e. processing wasn't scheduled again. In consequence, after such an error, the outbox was no longer processed.