### PR TITLE
Update gradle-build.yml / gradle-build-action

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       uses: gradle/gradle-build-action@v2.8.0
       with:
-        arguments: build -Porg.gradle.jvmargs=-Xmx2048m
+        arguments: build
 
   publish:
     needs: [ build ]

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Validate gradle wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Build
-      uses: gradle/gradle-build-action@v2.7.1
+      uses: gradle/gradle-build-action@v2.8.0
       with:
         arguments: build -Porg.gradle.jvmargs=-Xmx2048m
 
@@ -49,7 +49,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Publish
-        uses: gradle/gradle-build-action@v2.7.1
+        uses: gradle/gradle-build-action@v2.8.0
         env:
           # variables used by build.gradle.kts for signing / publishing (without 'ORG_GRADLE_PROJECT_' prefix)
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,8 @@ allprojects {
     }
 
     tasks.withType<Test> {
+        jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+
         useJUnitPlatform()
 
         testLogging {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,7 +126,7 @@ allprojects {
     }
 
     tasks.withType<Test> {
-        jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
+        jvmArgs(listOf("-Xmx2048m", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
 
         useJUnitPlatform()
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This should improve the issue with builds failing with an OOME, which might be related to https://github.com/gradle/gradle/issues/23215, which could be solved with gradle 8.3 (used by the new gradle-build-action according to https://github.com/gradle/gradle-build-action/compare/v2.7.1...v2.8.0).

Update after some builds and more changes: The final solution here is to set `jvmArgs` to "-Xmx2048m" for the test task. 