### PR TITLE
Change OutboxService to be more generic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 import java.util.*
 
-project(":commons").version = "2.0.2-SNAPSHOT"
+project(":commons").version = "2.1.0-SNAPSHOT"
 project(":outbox-kafka-spring").version = "3.0.0-SNAPSHOT"
 project(":outbox-kafka-spring-reactive").version = "3.0.0-SNAPSHOT"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 import java.util.*
 
 project(":commons").version = "2.0.2-SNAPSHOT"
-project(":outbox-kafka-spring").version = "2.0.2-SNAPSHOT"
-project(":outbox-kafka-spring-reactive").version = "2.0.2-SNAPSHOT"
+project(":outbox-kafka-spring").version = "3.0.0-SNAPSHOT"
+project(":outbox-kafka-spring-reactive").version = "3.0.0-SNAPSHOT"
 
 plugins {
     id("java-library")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,10 @@ subprojects {
 
         withJavadocJar()
         withSourcesJar()
+
+        registerFeature("protobufSupport") {
+            usingSourceSet(sourceSets["main"])
+        }
     }
 
     tasks.withType<Javadoc> {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -2,7 +2,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("org.apache.kafka:kafka-clients:3.5.1")
     implementation("org.springframework:spring-core:6.0.13")
     implementation("org.slf4j:slf4j-api:2.0.9")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("org.springframework:spring-r2dbc:$springVersion")
     implementation("org.postgresql:r2dbc-postgresql:1.0.2.RELEASE")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.3")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:2.0.9")

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxService.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.service;
+
+import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
+import one.tomorrow.transactionaloutbox.reactive.repository.OutboxRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.ReactiveTransactionManager;
+import org.springframework.transaction.reactive.TransactionalOperator;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord.toJson;
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_MANDATORY;
+
+@Service
+public class OutboxService {
+
+	private final OutboxRepository repository;
+	private final TransactionalOperator mandatoryTxOperator;
+
+	public OutboxService(OutboxRepository repository, ReactiveTransactionManager tm) {
+		this.repository = repository;
+
+		DefaultTransactionDefinition txDefinition = new DefaultTransactionDefinition();
+		txDefinition.setPropagationBehavior(PROPAGATION_MANDATORY);
+		mandatoryTxOperator = TransactionalOperator.create(tm, txDefinition);
+	}
+
+    public Mono<OutboxRecord> saveForPublishing(String topic, String key, byte[] event) {
+        return saveForPublishing(topic, key, event, null);
+    }
+
+	public Mono<OutboxRecord> saveForPublishing(String topic, String key, byte[] event, Map<String, String> headerMap) {
+		OutboxRecord record = OutboxRecord.builder()
+				.topic(topic)
+				.key(key)
+				.value(event)
+				.headers(toJson(headerMap))
+				.created(Instant.now())
+				.build();
+		return repository.save(record).as(mandatoryTxOperator::transactional);
+	}
+
+}

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxService.java
@@ -32,30 +32,30 @@ import static org.springframework.transaction.TransactionDefinition.PROPAGATION_
 @Service
 public class OutboxService {
 
-	private final OutboxRepository repository;
-	private final TransactionalOperator mandatoryTxOperator;
+    private final OutboxRepository repository;
+    private final TransactionalOperator mandatoryTxOperator;
 
-	public OutboxService(OutboxRepository repository, ReactiveTransactionManager tm) {
-		this.repository = repository;
+    public OutboxService(OutboxRepository repository, ReactiveTransactionManager tm) {
+        this.repository = repository;
 
-		DefaultTransactionDefinition txDefinition = new DefaultTransactionDefinition();
-		txDefinition.setPropagationBehavior(PROPAGATION_MANDATORY);
-		mandatoryTxOperator = TransactionalOperator.create(tm, txDefinition);
-	}
+        DefaultTransactionDefinition txDefinition = new DefaultTransactionDefinition();
+        txDefinition.setPropagationBehavior(PROPAGATION_MANDATORY);
+        mandatoryTxOperator = TransactionalOperator.create(tm, txDefinition);
+    }
 
     public Mono<OutboxRecord> saveForPublishing(String topic, String key, byte[] event) {
         return saveForPublishing(topic, key, event, null);
     }
 
-	public Mono<OutboxRecord> saveForPublishing(String topic, String key, byte[] event, Map<String, String> headerMap) {
-		OutboxRecord record = OutboxRecord.builder()
-				.topic(topic)
-				.key(key)
-				.value(event)
-				.headers(toJson(headerMap))
-				.created(Instant.now())
-				.build();
-		return repository.save(record).as(mandatoryTxOperator::transactional);
-	}
+    public Mono<OutboxRecord> saveForPublishing(String topic, String key, byte[] event, Map<String, String> headerMap) {
+        OutboxRecord record = OutboxRecord.builder()
+                .topic(topic)
+                .key(key)
+                .value(event)
+                .headers(toJson(headerMap))
+                .created(Instant.now())
+                .build();
+        return repository.save(record).as(mandatoryTxOperator::transactional);
+    }
 
 }

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
@@ -32,28 +32,28 @@ import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_VALU
 @Service
 public class ProtobufOutboxService {
 
-	private final OutboxService outboxService;
+    private final OutboxService outboxService;
 
-	public ProtobufOutboxService(OutboxService outboxService) {
-		this.outboxService = outboxService;
-	}
+    public ProtobufOutboxService(OutboxService outboxService) {
+        this.outboxService = outboxService;
+    }
 
     /**
      * Save the message/event (as byte array), setting the {@link one.tomorrow.transactionaloutbox.commons.KafkaHeaders#HEADERS_VALUE_TYPE_NAME}
      * to the fully qualified name of the message descriptor.
      */
-	public <T extends Message> Mono<OutboxRecord> saveForPublishing(String topic, String key, T event, Header...headers) {
+    public <T extends Message> Mono<OutboxRecord> saveForPublishing(String topic, String key, T event, Header...headers) {
         Header valueType = new Header(HEADERS_VALUE_TYPE_NAME, event.getDescriptorForType().getFullName());
-		Map<String, String> headerMap = Stream.concat(Stream.of(valueType), Arrays.stream(headers))
+        Map<String, String> headerMap = Stream.concat(Stream.of(valueType), Arrays.stream(headers))
                 .collect(Collectors.toMap(Header::getKey, Header::getValue));
         return outboxService.saveForPublishing(topic, key, event.toByteArray(), headerMap);
-	}
+    }
 
-	@Getter
-	@RequiredArgsConstructor
-	public static class Header {
-		private final String key;
-		private final String value;
-	}
+    @Getter
+    @RequiredArgsConstructor
+    public static class Header {
+        private final String key;
+        private final String value;
+    }
 
 }

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
@@ -37,12 +37,12 @@ import static one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord.toJso
 import static org.springframework.transaction.TransactionDefinition.PROPAGATION_MANDATORY;
 
 @Service
-public class OutboxService {
+public class ProtobufOutboxService {
 
 	private final OutboxRepository repository;
 	private final TransactionalOperator mandatoryTxOperator;
 
-	public OutboxService(OutboxRepository repository, ReactiveTransactionManager tm) {
+	public ProtobufOutboxService(OutboxRepository repository, ReactiveTransactionManager tm) {
 		this.repository = repository;
 
 		DefaultTransactionDefinition txDefinition = new DefaultTransactionDefinition();

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
@@ -19,49 +19,34 @@ import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
-import one.tomorrow.transactionaloutbox.reactive.repository.OutboxRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.ReactiveTransactionManager;
-import org.springframework.transaction.reactive.TransactionalOperator;
-import org.springframework.transaction.support.DefaultTransactionDefinition;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_VALUE_TYPE_NAME;
-import static one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord.toJson;
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_MANDATORY;
 
 @Service
 public class ProtobufOutboxService {
 
-	private final OutboxRepository repository;
-	private final TransactionalOperator mandatoryTxOperator;
+	private final OutboxService outboxService;
 
-	public ProtobufOutboxService(OutboxRepository repository, ReactiveTransactionManager tm) {
-		this.repository = repository;
-
-		DefaultTransactionDefinition txDefinition = new DefaultTransactionDefinition();
-		txDefinition.setPropagationBehavior(PROPAGATION_MANDATORY);
-		mandatoryTxOperator = TransactionalOperator.create(tm, txDefinition);
+	public ProtobufOutboxService(OutboxService outboxService) {
+		this.outboxService = outboxService;
 	}
 
+    /**
+     * Save the message/event (as byte array), setting the {@link one.tomorrow.transactionaloutbox.commons.KafkaHeaders#HEADERS_VALUE_TYPE_NAME}
+     * to the fully qualified name of the message descriptor.
+     */
 	public <T extends Message> Mono<OutboxRecord> saveForPublishing(String topic, String key, T event, Header...headers) {
         Header valueType = new Header(HEADERS_VALUE_TYPE_NAME, event.getDescriptorForType().getFullName());
 		Map<String, String> headerMap = Stream.concat(Stream.of(valueType), Arrays.stream(headers))
                 .collect(Collectors.toMap(Header::getKey, Header::getValue));
-		OutboxRecord record = OutboxRecord.builder()
-				.topic(topic)
-				.key(key)
-				.value(event.toByteArray())
-				.headers(toJson(headerMap))
-				.created(Instant.now())
-				.build();
-		return repository.save(record).as(mandatoryTxOperator::transactional);
+        return outboxService.saveForPublishing(topic, key, event.toByteArray(), headerMap);
 	}
 
 	@Getter

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/AbstractIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/AbstractIntegrationTest.java
@@ -18,7 +18,7 @@ package one.tomorrow.transactionaloutbox.reactive;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxLock;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.reactive.service.OutboxLockService;
-import one.tomorrow.transactionaloutbox.reactive.service.OutboxService;
+import one.tomorrow.transactionaloutbox.reactive.service.ProtobufOutboxService;
 import org.flywaydb.test.junit5.annotation.FlywayTestExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
@@ -36,7 +36,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
         OutboxLockRepository.class,
         OutboxLock.class,
         OutboxLockService.class,
-        OutboxService.class,
+        ProtobufOutboxService.class,
         IntegrationTestConfig.class
 })
 @Testcontainers

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/AbstractIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/AbstractIntegrationTest.java
@@ -36,7 +36,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
         OutboxLockRepository.class,
         OutboxLock.class,
         OutboxLockService.class,
-        ProtobufOutboxService.class,
         IntegrationTestConfig.class
 })
 @Testcontainers

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxServiceIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Tomorrow GmbH @ https://tomorrow.one
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import one.tomorrow.transactionaloutbox.reactive.model.OutboxLock;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxRepository;
-import one.tomorrow.transactionaloutbox.reactive.test.Sample.SomethingHappened;
 import org.flywaydb.test.annotation.FlywayTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -34,28 +33,28 @@ import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
 
 @ContextConfiguration(classes = {
         OutboxLockRepository.class,
         OutboxLock.class,
         OutboxLockService.class,
         OutboxService.class,
-        ProtobufOutboxService.class,
         IntegrationTestConfig.class
 })
 @FlywayTest
 @SuppressWarnings({"unused", "ConstantConditions"})
-class ProtobufOutboxServiceIntegrationTest extends AbstractIntegrationTest {
+class OutboxServiceIntegrationTest extends AbstractIntegrationTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(ProtobufOutboxServiceIntegrationTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(OutboxServiceIntegrationTest.class);
 
     @Autowired
-    private ProtobufOutboxService testee;
+    private OutboxService testee;
     @Autowired
     private OutboxRepository repository;
     @Autowired
@@ -69,10 +68,10 @@ class ProtobufOutboxServiceIntegrationTest extends AbstractIntegrationTest {
     @Test
     void should_failOnMissingTransaction() {
         // given
-        SomethingHappened message = SomethingHappened.newBuilder().setId(1).setName("foo").build();
+        String message = "foo";
 
         // when
-        Mono<OutboxRecord> result = testee.saveForPublishing("protobuf_topic", "key", message);
+        Mono<OutboxRecord> result = testee.saveForPublishing("topic", "key", message.getBytes());
 
         // then
         StepVerifier.create(result)
@@ -83,10 +82,10 @@ class ProtobufOutboxServiceIntegrationTest extends AbstractIntegrationTest {
     @Test
     void should_save_withExistingTransaction() {
         // given
-        SomethingHappened message = SomethingHappened.newBuilder().setId(1).setName("foo").build();
+        String message = "foo";
 
         // when
-        Mono<OutboxRecord> result = testee.saveForPublishing("protobuf_topic", "key", message)
+        Mono<OutboxRecord> result = testee.saveForPublishing("topic", "key", message.getBytes())
                 .as(rxtx::transactional);
 
         // then
@@ -100,11 +99,11 @@ class ProtobufOutboxServiceIntegrationTest extends AbstractIntegrationTest {
     @Test
     void should_save_withAdditionalHeader() {
         // given
-        SomethingHappened message = SomethingHappened.newBuilder().setId(1).setName("foo").build();
-        ProtobufOutboxService.Header additionalHeader = new ProtobufOutboxService.Header("key", "value");
+        String message = "foo";
+        Map<String, String> additionalHeader = Map.of("key", "value");
 
         // when
-        Mono<OutboxRecord> result = testee.saveForPublishing("topic", "key", message, additionalHeader)
+        Mono<OutboxRecord> result = testee.saveForPublishing("topic", "key", message.getBytes(), additionalHeader)
                 .as(rxtx::transactional);
 
         // then
@@ -113,7 +112,8 @@ class ProtobufOutboxServiceIntegrationTest extends AbstractIntegrationTest {
 
         OutboxRecord foundRecord = repository.findById(savedRecord.getId()).block();
         assertThat(foundRecord, is(notNullValue()));
-        assertThat(foundRecord.getHeadersAsMap(), hasEntry(additionalHeader.getKey(), additionalHeader.getValue()));
+        Map.Entry<String, String> entry = additionalHeader.entrySet().iterator().next();
+        assertThat(foundRecord.getHeadersAsMap(), hasEntry(entry.getKey(), entry.getValue()));
     }
 
 }

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxServiceIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxServiceIntegrationTest.java
@@ -30,7 +30,6 @@ import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,12 +38,12 @@ import static org.hamcrest.collection.IsMapContaining.hasKey;
 
 @FlywayTest
 @SuppressWarnings({"unused", "ConstantConditions"})
-class OutboxServiceIntegrationTest extends AbstractIntegrationTest {
+class ProtobufOutboxServiceIntegrationTest extends AbstractIntegrationTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(OutboxServiceIntegrationTest.class);
+    private static final Logger logger = LoggerFactory.getLogger(ProtobufOutboxServiceIntegrationTest.class);
 
     @Autowired
-    private OutboxService testee;
+    private ProtobufOutboxService testee;
     @Autowired
     private OutboxRepository repository;
     @Autowired
@@ -90,7 +89,7 @@ class OutboxServiceIntegrationTest extends AbstractIntegrationTest {
     void should_save_withAdditionalHeader() {
         // given
         SomethingHappened message = SomethingHappened.newBuilder().setId(1).setName("foo").build();
-        OutboxService.Header additionalHeader = new OutboxService.Header("key", "value");
+        ProtobufOutboxService.Header additionalHeader = new ProtobufOutboxService.Header("key", "value");
 
         // when
         Mono<OutboxRecord> result = testee.saveForPublishing("topic", "key", message, additionalHeader)

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.hibernate.orm:hibernate-core:$hibernateVersion")
     implementation("com.vladmihalcea:hibernate-types-60:2.21.1")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:2.0.9")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.1")

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxService.java
@@ -26,21 +26,21 @@ import java.util.Map;
 @AllArgsConstructor
 public class OutboxService {
 
-	private OutboxRepository repository;
+    private OutboxRepository repository;
 
     public OutboxRecord saveForPublishing(String topic, String key, byte[] value) {
         return saveForPublishing(topic, key, value, null);
     }
 
-	public OutboxRecord saveForPublishing(String topic, String key, byte[] value, Map<String, String> headerMap) {
-		OutboxRecord record = OutboxRecord.builder()
-				.topic(topic)
-				.key(key)
-				.value(value)
-				.headers(headerMap)
-				.build();
-		repository.persist(record);
-		return record;
-	}
+    public OutboxRecord saveForPublishing(String topic, String key, byte[] value, Map<String, String> headerMap) {
+        OutboxRecord record = OutboxRecord.builder()
+                .topic(topic)
+                .key(key)
+                .value(value)
+                .headers(headerMap)
+                .build();
+        repository.persist(record);
+        return record;
+    }
 
 }

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxService.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.service;
+
+import lombok.AllArgsConstructor;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import one.tomorrow.transactionaloutbox.repository.OutboxRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@AllArgsConstructor
+public class OutboxService {
+
+	private OutboxRepository repository;
+
+    public OutboxRecord saveForPublishing(String topic, String key, byte[] value) {
+        return saveForPublishing(topic, key, value, null);
+    }
+
+	public OutboxRecord saveForPublishing(String topic, String key, byte[] value, Map<String, String> headerMap) {
+		OutboxRecord record = OutboxRecord.builder()
+				.topic(topic)
+				.key(key)
+				.value(value)
+				.headers(headerMap)
+				.build();
+		repository.persist(record);
+		return record;
+	}
+
+}

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxService.java
@@ -32,7 +32,7 @@ import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_VALU
 
 @Service
 @AllArgsConstructor
-public class OutboxService {
+public class ProtobufOutboxService {
 
 	private OutboxRepository repository;
 

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxService.java
@@ -33,25 +33,25 @@ import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_VALU
 @AllArgsConstructor
 public class ProtobufOutboxService {
 
-	private OutboxService outboxService;
+    private OutboxService outboxService;
 
     /**
      * Save the message/event (as byte array), setting the {@link one.tomorrow.transactionaloutbox.commons.KafkaHeaders#HEADERS_VALUE_TYPE_NAME}
      * to the fully qualified name of the message descriptor.
      */
-	public <T extends Message> OutboxRecord saveForPublishing(String topic, String key, T event, Header...headers) {
-		byte[] value = event.toByteArray();
-		Header valueType = new Header(HEADERS_VALUE_TYPE_NAME, event.getDescriptorForType().getFullName());
-		Map<String, String> headerMap = Stream.concat(Stream.of(valueType), Arrays.stream(headers))
-				.collect(Collectors.toMap(Header::getKey, Header::getValue));
-		return outboxService.saveForPublishing(topic, key, value, headerMap);
-	}
+    public <T extends Message> OutboxRecord saveForPublishing(String topic, String key, T event, Header...headers) {
+        byte[] value = event.toByteArray();
+        Header valueType = new Header(HEADERS_VALUE_TYPE_NAME, event.getDescriptorForType().getFullName());
+        Map<String, String> headerMap = Stream.concat(Stream.of(valueType), Arrays.stream(headers))
+                .collect(Collectors.toMap(Header::getKey, Header::getValue));
+        return outboxService.saveForPublishing(topic, key, value, headerMap);
+    }
 
-	@Getter
-	@RequiredArgsConstructor
-	public static class Header {
-		private final String key;
-		private final String value;
-	}
+    @Getter
+    @RequiredArgsConstructor
+    public static class Header {
+        private final String key;
+        private final String value;
+    }
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxUsageIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxUsageIntegrationTest.java
@@ -56,7 +56,7 @@ import java.util.List;
 import java.util.Map;
 
 import static one.tomorrow.transactionaloutbox.IntegrationTestConfig.DEFAULT_OUTBOX_LOCK_TIMEOUT;
-import static one.tomorrow.transactionaloutbox.service.SampleService.Topics.topic1;
+import static one.tomorrow.transactionaloutbox.service.SampleProtobufService.Topics.topic1;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.springframework.kafka.test.utils.KafkaTestUtils.producerProps;
@@ -67,10 +67,10 @@ import static org.springframework.kafka.test.utils.KafkaTestUtils.producerProps;
         OutboxRepository.class,
         OutboxLock.class,
         OutboxLockRepository.class,
-        OutboxService.class,
-        SampleService.class,
+        ProtobufOutboxService.class,
+        SampleProtobufService.class,
         IntegrationTestConfig.class,
-        OutboxUsageIntegrationTest.OutboxProcessorSetup.class
+        ProtobufOutboxUsageIntegrationTest.OutboxProcessorSetup.class
 })
 @TestExecutionListeners({
         DependencyInjectionTestExecutionListener.class,
@@ -78,7 +78,7 @@ import static org.springframework.kafka.test.utils.KafkaTestUtils.producerProps;
 })
 @FlywayTest
 @SuppressWarnings("unused")
-public class OutboxUsageIntegrationTest {
+public class ProtobufOutboxUsageIntegrationTest {
 
     @ClassRule
     public static EmbeddedKafkaRule kafkaRule = new EmbeddedKafkaRule(1, true, 5, topic1)
@@ -86,7 +86,7 @@ public class OutboxUsageIntegrationTest {
     private static Consumer<String, Message> consumer;
 
     @Autowired
-    private SampleService sampleService;
+    private SampleProtobufService sampleService;
     @Autowired
     private ApplicationContext applicationContext;
 
@@ -133,7 +133,7 @@ public class OutboxUsageIntegrationTest {
         // when
         int id = 24;
         String name = "foo bar baz";
-        OutboxService.Header additionalHeader = new OutboxService.Header("key", "value");
+        ProtobufOutboxService.Header additionalHeader = new ProtobufOutboxService.Header("key", "value");
         sampleService.doSomethingWithAdditionalHeaders(id, name, additionalHeader);
 
         // then

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleProtobufService.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleProtobufService.java
@@ -59,7 +59,7 @@ public class SampleProtobufService {
 	}
 
 	abstract static class Topics {
-		public static final String topic1 = "sampleTopic";
+		public static final String topic1 = "sampleProtobufTopic";
 	}
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleProtobufService.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleProtobufService.java
@@ -30,36 +30,36 @@ import static one.tomorrow.transactionaloutbox.service.SampleProtobufService.Top
 @AllArgsConstructor
 public class SampleProtobufService {
 
-	private static final Logger logger = LoggerFactory.getLogger(SampleProtobufService.class);
+    private static final Logger logger = LoggerFactory.getLogger(SampleProtobufService.class);
 
-	private ProtobufOutboxService outboxService;
+    private ProtobufOutboxService outboxService;
 
-	@Transactional
-	public void doSomething(int id, String name) {
-		// Here s.th. else would be done within the transaction, e.g. some entity created.
-		// We record this fact with the event that shall be published to interested parties / consumers.
-		SomethingHappened event = SomethingHappened.newBuilder()
-				.setId(id)
-				.setName(name)
-				.build();
-		OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), event);
-		logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", event, record.getId(), record.getKey(), record.getHeaders());
-	}
+    @Transactional
+    public void doSomething(int id, String name) {
+        // Here s.th. else would be done within the transaction, e.g. some entity created.
+        // We record this fact with the event that shall be published to interested parties / consumers.
+        SomethingHappened event = SomethingHappened.newBuilder()
+                .setId(id)
+                .setName(name)
+                .build();
+        OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), event);
+        logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", event, record.getId(), record.getKey(), record.getHeaders());
+    }
 
-	@Transactional
-	public void doSomethingWithAdditionalHeaders(int id, String name, Header...headers) {
-		// Here s.th. else would be done within the transaction, e.g. some entity created.
-		// We record this fact with the event that shall be published to interested parties / consumers.
-		SomethingHappened event = SomethingHappened.newBuilder()
-				.setId(id)
-				.setName(name)
-				.build();
-		OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), event, headers);
-		logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", event, record.getId(), record.getKey(), record.getHeaders());
-	}
+    @Transactional
+    public void doSomethingWithAdditionalHeaders(int id, String name, Header...headers) {
+        // Here s.th. else would be done within the transaction, e.g. some entity created.
+        // We record this fact with the event that shall be published to interested parties / consumers.
+        SomethingHappened event = SomethingHappened.newBuilder()
+                .setId(id)
+                .setName(name)
+                .build();
+        OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), event, headers);
+        logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", event, record.getId(), record.getKey(), record.getHeaders());
+    }
 
-	abstract static class Topics {
-		public static final String topic1 = "sampleProtobufTopic";
-	}
+    abstract static class Topics {
+        public static final String topic1 = "sampleProtobufTopic";
+    }
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleProtobufService.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleProtobufService.java
@@ -17,22 +17,22 @@ package one.tomorrow.transactionaloutbox.service;
 
 import lombok.AllArgsConstructor;
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
-import one.tomorrow.transactionaloutbox.service.OutboxService.Header;
+import one.tomorrow.transactionaloutbox.service.ProtobufOutboxService.Header;
 import one.tomorrow.transactionaloutbox.test.Sample.SomethingHappened;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static one.tomorrow.transactionaloutbox.service.SampleService.Topics.topic1;
+import static one.tomorrow.transactionaloutbox.service.SampleProtobufService.Topics.topic1;
 
 @Service
 @AllArgsConstructor
-public class SampleService {
+public class SampleProtobufService {
 
-	private static final Logger logger = LoggerFactory.getLogger(SampleService.class);
+	private static final Logger logger = LoggerFactory.getLogger(SampleProtobufService.class);
 
-	private OutboxService outboxService;
+	private ProtobufOutboxService outboxService;
 
 	@Transactional
 	public void doSomething(int id, String name) {

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleService.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleService.java
@@ -34,27 +34,27 @@ import static one.tomorrow.transactionaloutbox.service.SampleService.Topics.topi
 @AllArgsConstructor
 public class SampleService {
 
-	private static final Logger logger = LoggerFactory.getLogger(SampleService.class);
+    private static final Logger logger = LoggerFactory.getLogger(SampleService.class);
 
-	private OutboxService outboxService;
+    private OutboxService outboxService;
 
-	@Transactional
-	public void doSomething(int id, String something) {
-		// Here s.th. else would be done within the transaction, e.g. some entity created.
-		// We record this fact with the event that shall be published to interested parties / consumers.
-		OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes());
-		logger.info("Stored event [{}] in outbox with id {} and key {}", something, record.getId(), record.getKey());
-	}
+    @Transactional
+    public void doSomething(int id, String something) {
+        // Here s.th. else would be done within the transaction, e.g. some entity created.
+        // We record this fact with the event that shall be published to interested parties / consumers.
+        OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes());
+        logger.info("Stored event [{}] in outbox with id {} and key {}", something, record.getId(), record.getKey());
+    }
 
-	@Transactional
-	public void doSomethingWithAdditionalHeaders(int id, String something, Header...headers) {
-		// Here s.th. else would be done within the transaction, e.g. some entity created.
-		// We record this fact with the event that shall be published to interested parties / consumers.
+    @Transactional
+    public void doSomethingWithAdditionalHeaders(int id, String something, Header...headers) {
+        // Here s.th. else would be done within the transaction, e.g. some entity created.
+        // We record this fact with the event that shall be published to interested parties / consumers.
         Map<String, String> headerMap = Arrays.stream(headers)
                 .collect(Collectors.toMap(Header::getKey, Header::getValue));
-		OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes(), headerMap);
-		logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", something, record.getId(), record.getKey(), record.getHeaders());
-	}
+        OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes(), headerMap);
+        logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", something, record.getId(), record.getKey(), record.getHeaders());
+    }
 
     @Getter
     @RequiredArgsConstructor
@@ -63,8 +63,8 @@ public class SampleService {
         private final String value;
     }
 
-	abstract static class Topics {
-		public static final String topic1 = "sampleTopic";
-	}
+    abstract static class Topics {
+        public static final String topic1 = "sampleTopic";
+    }
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleService.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleService.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static one.tomorrow.transactionaloutbox.service.SampleService.Topics.topic1;
+
+@Service
+@AllArgsConstructor
+public class SampleService {
+
+	private static final Logger logger = LoggerFactory.getLogger(SampleService.class);
+
+	private OutboxService outboxService;
+
+	@Transactional
+	public void doSomething(int id, String something) {
+		// Here s.th. else would be done within the transaction, e.g. some entity created.
+		// We record this fact with the event that shall be published to interested parties / consumers.
+		OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes());
+		logger.info("Stored event [{}] in outbox with id {} and key {}", something, record.getId(), record.getKey());
+	}
+
+	@Transactional
+	public void doSomethingWithAdditionalHeaders(int id, String something, Header...headers) {
+		// Here s.th. else would be done within the transaction, e.g. some entity created.
+		// We record this fact with the event that shall be published to interested parties / consumers.
+        Map<String, String> headerMap = Arrays.stream(headers)
+                .collect(Collectors.toMap(Header::getKey, Header::getValue));
+		OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes(), headerMap);
+		logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", something, record.getId(), record.getKey(), record.getHeaders());
+	}
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Header {
+        private final String key;
+        private final String value;
+    }
+
+	abstract static class Topics {
+		public static final String topic1 = "sampleTopic";
+	}
+
+}


### PR DESCRIPTION
The `OutboxService` is now quite generic, accepting just `byte[]` as value. For existing client applications using protobuf for message serialization, the former `OutboxService` is now available as `ProtobufOutboxService`.

Because this is a binary incompatitble change, the major version is incremented.

@hnrkdmsk @danielrehmann This is valuable so that other projects not using protobuf can easier adapt this project. I'm well aware that for Tomorrow that means to change imports / rename things, but I think this is worth it. E.g. a `GenericOutboxService` and an `OutboxService` accepting protobuf messages would not be very clean IMHO.