### PR TITLE
Make protobuf support optional

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,10 @@ subprojects {
 
         withJavadocJar()
         withSourcesJar()
+
+        registerFeature("protobufSupport") {
+            usingSourceSet(sourceSets["main"])
+        }
     }
 
     tasks.withType<Javadoc> {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -2,7 +2,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("org.apache.kafka:kafka-clients:3.5.1")
     implementation("org.springframework:spring-core:6.0.13")
     implementation("org.slf4j:slf4j-api:2.0.9")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("org.springframework:spring-r2dbc:$springVersion")
     implementation("org.postgresql:r2dbc-postgresql:1.0.2.RELEASE")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.3")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:2.0.9")

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.hibernate.orm:hibernate-core:$hibernateVersion")
     implementation("com.vladmihalcea:hibernate-types-60:2.21.1")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
-    implementation("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
+    "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation(project(":commons"))
     implementation("org.slf4j:slf4j-api:2.0.9")
     implementation("jakarta.annotation:jakarta.annotation-api:2.1.1")


### PR DESCRIPTION
So that applications that don't use protobuf don't get a transitive protobuf dependency. I.e. the resulting pom.xml shouldn't contain the protobuf dependency. 