### PR TITLE
Fix protobuf classpath dependency for classpath scanning

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -2,9 +2,12 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
+    val springVersion = "6.0.13"
+
     "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("org.apache.kafka:kafka-clients:3.5.1")
-    implementation("org.springframework:spring-core:6.0.13")
+    implementation("org.springframework:spring-core:$springVersion")
+    implementation("org.springframework:spring-context:$springVersion")
     implementation("org.slf4j:slf4j-api:2.0.9")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")

--- a/commons/src/main/java/one/tomorrow/transactionaloutbox/commons/spring/ConditionalOnClass.java
+++ b/commons/src/main/java/one/tomorrow/transactionaloutbox/commons/spring/ConditionalOnClass.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.commons.spring;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnClassCondition.class)
+public @interface ConditionalOnClass {
+
+    /** The class that must be present. */
+    Class<?> value();
+
+}

--- a/commons/src/main/java/one/tomorrow/transactionaloutbox/commons/spring/OnClassCondition.java
+++ b/commons/src/main/java/one/tomorrow/transactionaloutbox/commons/spring/OnClassCondition.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.commons.spring;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class OnClassCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        String className = metadata.getAnnotations().get(ConditionalOnClass.class).getString("value");
+        try {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            ClassLoader beanClassLoader;
+            if (beanFactory != null && (beanClassLoader = beanFactory.getBeanClassLoader()) != null) {
+                beanClassLoader.loadClass(className);
+                return true;
+            }
+        } catch (ClassNotFoundException e) {
+            // ignore
+        }
+        return false;
+    }
+
+}

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxService.java
@@ -18,6 +18,7 @@ package one.tomorrow.transactionaloutbox.reactive.service;
 import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import one.tomorrow.transactionaloutbox.commons.spring.ConditionalOnClass;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
@@ -30,6 +31,7 @@ import java.util.stream.Stream;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_VALUE_TYPE_NAME;
 
 @Service
+@ConditionalOnClass(Message.class)
 public class ProtobufOutboxService {
 
     private final OutboxService outboxService;

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxService.java
@@ -19,6 +19,7 @@ import com.google.protobuf.Message;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import one.tomorrow.transactionaloutbox.commons.spring.ConditionalOnClass;
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,7 @@ import java.util.stream.Stream;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_VALUE_TYPE_NAME;
 
 @Service
+@ConditionalOnClass(Message.class)
 @AllArgsConstructor
 public class ProtobufOutboxService {
 


### PR DESCRIPTION
When the library is integrated together with `@ComponentScan` and protobuf is not on the classpath, the application start failed with a `NoClassDefFoundError` for the protobuf `Message`:

```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'protobufOutboxService': Lookup method resolution failed
    ...
Caused by: java.lang.NoClassDefFoundError: com/google/protobuf/Message
    at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
    at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3402)
    at java.base/java.lang.Class.getDeclaredMethods(Class.java:2504)
    at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:465)
```

This is fixed now with a custom `Conditional` annotation on `ProtobufOutboxService`, which prevents loading if `Message` is not on the classpath.

While spring boot already provides a `ConditionalOnClass` annotation, this would have pulled in a dependency on spring-boot, which would be a big thing for spring-classic applications. Therefore, we have our own `ConditionalOnClass` annotation now.