### PR TITLE
Try to fix OutOfMemoryErrors in tests

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -35,7 +35,7 @@ jobs:
       uses: gradle/gradle-build-action@v2.8.0
       with:
         gradle-version: 8.4
-        arguments: build -Dorg.gradle.jvmargs=-Xmx2g
+        arguments: build -Dorg.gradle.jvmargs=-Xmx4g
 
   publish:
     needs: [ build ]

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build
       uses: gradle/gradle-build-action@v2.8.0
       with:
+        gradle-version: 8.4
         arguments: build -Dorg.gradle.jvmargs=-Xmx2g
 
   publish:

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       uses: gradle/gradle-build-action@v2.8.0
       with:
-        arguments: build
+        arguments: build -Dorg.gradle.jvmargs=-Xmx2g
 
   publish:
     needs: [ build ]

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -34,8 +34,7 @@ jobs:
     - name: Build
       uses: gradle/gradle-build-action@v2.8.0
       with:
-        gradle-version: 8.4
-        arguments: build -Dorg.gradle.jvmargs=-Xmx4g
+        arguments: build
 
   publish:
     needs: [ build ]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,7 +130,8 @@ allprojects {
     }
 
     tasks.withType<Test> {
-        jvmArgs(listOf("-Xmx2048m", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
+        jvmArgs(listOf("--add-opens=java.base/java.lang=ALL-UNNAMED"))
+        maxHeapSize = "2048m"
 
         useJUnitPlatform()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,7 +130,7 @@ allprojects {
     }
 
     tasks.withType<Test> {
-        jvmArgs(listOf("-Xmx2048m", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
+        jvmArgs(listOf("-Xmx4g", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
 
         useJUnitPlatform()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,7 +130,7 @@ allprojects {
     }
 
     tasks.withType<Test> {
-        jvmArgs(listOf("-Xmx4g", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
+        jvmArgs(listOf("--add-opens=java.base/java.lang=ALL-UNNAMED"))
         maxHeapSize = "4g"
 
         useJUnitPlatform()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,8 +130,7 @@ allprojects {
     }
 
     tasks.withType<Test> {
-        jvmArgs(listOf("--add-opens=java.base/java.lang=ALL-UNNAMED"))
-        maxHeapSize = "2048m"
+        jvmArgs(listOf("-Xmx2048m", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
 
         useJUnitPlatform()
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,7 @@ allprojects {
 
     tasks.withType<Test> {
         jvmArgs(listOf("-Xmx4g", "--add-opens=java.base/java.lang=ALL-UNNAMED"))
+        maxHeapSize = "4g"
 
         useJUnitPlatform()
 


### PR DESCRIPTION
OOMEs happen now and then, e.g. here
https://github.com/tomorrow-one/transactional-outbox/actions/runs/6864042811/job/18664975293 or here
https://github.com/tomorrow-one/transactional-outbox/actions/runs/6864042811/job/18665221337 (note that the build was green, despite the OOME)

To specify max heap size via `maxHeapSize` and not `jvmArgs` is just a try, not sure if this fixes it.