### PR TITLE
acquireOrRefreshLock: Reduce log level for INFO

### DIFF
--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
@@ -89,7 +89,7 @@ public class OutboxLockRepository {
             }
 
             txStatus.flush();
-            logger.info("Acquired or refreshed outbox lock for owner {}, valid until {}", ownerId, validUntil);
+            logger.debug("Acquired or refreshed outbox lock for owner {}, valid until {}", ownerId, validUntil);
             return true;
         } catch (UncategorizedSQLException e) {
             return handleException(e, ownerId);

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepository.java
@@ -68,7 +68,7 @@ public class OutboxLockRepository {
         try {
             OutboxLock lock = jdbcTemplate.query("select * from outbox_kafka_lock where id = '" + OUTBOX_LOCK_ID + "'", resultSetExtractor);
             if (lock == null) {
-                logger.debug("No outbox lock found. Creating one for {}", ownerId);
+                logger.info("No outbox lock found. Creating one for {}", ownerId);
                 validUntil = now.plus(timeout);
                 jdbcTemplate.update("insert into outbox_kafka_lock (id, owner_id, valid_until) values (?, ?, ?)", OUTBOX_LOCK_ID, ownerId, Timestamp.from(validUntil));
             } else if (ownerId.equals(lock.getOwnerId())) {


### PR DESCRIPTION
Currently, this message is logged every Duration of `lockTimeout`. In our case, this is every 4 seconds, which is quite much for my taste for an INFO logging...

Let me know if you need a ticket for this minor change...