### PR TITLE
Use kafka-testcontainers in outbox-kafka-spring

### DIFF
--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -25,12 +25,15 @@ dependencies {
 
     testImplementation("org.springframework:spring-test:$springVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")
+    testImplementation("org.testcontainers:kafka:$testcontainersVersion")
     testImplementation("org.testcontainers:toxiproxy:$testcontainersVersion")
     testImplementation("org.flywaydb:flyway-database-postgresql:10.1.0")
     testImplementation("org.flywaydb.flyway-test-extensions:flyway-spring-test:9.5.0")
     testImplementation("org.apache.kafka:kafka_2.13:$kafkaVersion") // specify explicitly to prevent conflicts of different server and client versions
     testImplementation("org.springframework.kafka:spring-kafka:$springKafkaVersion")
-    testImplementation("org.springframework.kafka:spring-kafka-test:$springKafkaVersion")
+    testImplementation("org.springframework.kafka:spring-kafka-test:$springKafkaVersion") {
+        exclude("org.apache.kafka:kafka_2.13", "junit")
+    }
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
     testImplementation("org.apache.commons:commons-dbcp2:2.11.0")

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -104,7 +104,7 @@ public class OutboxProcessor {
 
     @PreDestroy
     public void close() {
-        logger.info("Stopping OutboxProcessor.");
+        logger.info("Stopping OutboxProcessor with lockOwnerId {}.", lockOwnerId);
         if (schedule != null)
             schedule.cancel(false);
         executor.shutdown();

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/KafkaTestSupport.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/KafkaTestSupport.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox;
+
+import com.google.protobuf.Message;
+import one.tomorrow.transactionaloutbox.commons.KafkaProtobufSerializer;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import one.tomorrow.transactionaloutbox.service.DefaultKafkaProducerFactory;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SEQUENCE_NAME;
+import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SOURCE_NAME;
+import static one.tomorrow.transactionaloutbox.commons.Longs.toLong;
+import static one.tomorrow.transactionaloutbox.ProxiedKafkaContainer.bootstrapServers;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public interface KafkaTestSupport<T> {
+
+    static Map<String, Object> consumerProps(String bootstrapServers, String group, boolean autoCommit) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, group);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, autoCommit);
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "10");
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "60000");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return props;
+    }
+
+    static Consumer<String, byte[]> createConsumer(String bootstrapServers) {
+        return createConsumer(bootstrapServers, ByteArrayDeserializer.class);
+    }
+
+    static <T> Consumer<String, T> createConsumer(String bootstrapServers, Class<? extends Deserializer<T>> deserializerClass) {
+        Map<String, Object> consumerProps = consumerProps(bootstrapServers, "testGroup", true);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerClass);
+        DefaultKafkaConsumerFactory<String, T> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+        // use unique groupId, so that a new consumer does not get into conflicts with some previous one, which might not yet be fully shutdown
+        return cf.createConsumer("testConsumer-" + System.currentTimeMillis(), "someClientIdSuffix");
+    }
+
+    static Map<String, Object> producerProps(String bootstrapServers) {
+        return new HashMap<>(Map.of(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers));
+    }
+
+    static DefaultKafkaProducerFactory producerFactory() {
+        return producerFactory(producerProps(bootstrapServers));
+    }
+
+    static DefaultKafkaProducerFactory producerFactory(Map<String, Object> producerProps) {
+        return new DefaultKafkaProducerFactory(producerProps);
+    }
+
+    static KafkaProducer<String, Message> createTopicAndProducer(String bootstrapServers, String ... topics) {
+        createTopic(bootstrapServers, topics);
+        return createProducer(bootstrapServers);
+    }
+
+    static KafkaProducer<String, Message> createProducer(String bootstrapServers) {
+        Map<String, Object> props = producerProps(bootstrapServers);
+        props.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class);
+        return new KafkaProducer<>(props);
+    }
+
+    static void createTopic(String bootstrapServers, String ... topics) {
+        Map<String, Object> props = producerProps(bootstrapServers);
+        try (AdminClient client = AdminClient.create(props)) {
+            List<NewTopic> newTopics = Arrays.stream(topics)
+                    .map(topic -> new NewTopic(topic, 1, (short) 1))
+                    .collect(toList());
+            try {
+                client.createTopics(newTopics).all().get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    static void assertConsumedRecord(OutboxRecord outboxRecord, String sourceHeaderValue, ConsumerRecord<String, byte[]> kafkaRecord) {
+        assertEquals(
+                outboxRecord.getId().longValue(),
+                toLong(kafkaRecord.headers().lastHeader(HEADERS_SEQUENCE_NAME).value()),
+                "OutboxRecord id and " + HEADERS_SEQUENCE_NAME + " headers do not match"
+        );
+        assertArrayEquals(sourceHeaderValue.getBytes(), kafkaRecord.headers().lastHeader(HEADERS_SOURCE_NAME).value());
+        outboxRecord.getHeaders().forEach((key, value) ->
+                assertArrayEquals(value.getBytes(), kafkaRecord.headers().lastHeader(key).value())
+        );
+        assertEquals(outboxRecord.getKey(), kafkaRecord.key());
+        assertArrayEquals(outboxRecord.getValue(), kafkaRecord.value());
+    }
+
+    default ConsumerRecords<String, T> getAndCommitRecords() {
+        return getAndCommitRecords(-1);
+    }
+
+    default ConsumerRecords<String, T> getAndCommitRecords(int minRecords) {
+        ConsumerRecords<String, T> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(10), minRecords);
+        consumer().commitSync();
+        return records;
+    }
+
+    Consumer<String, T> consumer();
+
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/ProxiedKafkaContainer.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/ProxiedKafkaContainer.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox;
+
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.ToxiproxyContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class ProxiedKafkaContainer extends KafkaContainer {
+
+    private static ProxiedKafkaContainer kafka;
+    private static ToxiproxyContainer toxiproxy;
+    public static ToxiproxyContainer.ContainerProxy kafkaProxy;
+    public static String bootstrapServers;
+
+    public ProxiedKafkaContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+
+    public static ProxiedKafkaContainer startProxiedKafka() {
+        if (kafka == null) {
+            int exposedKafkaPort = KAFKA_PORT;
+
+            Network network = Network.newNetwork();
+
+            kafka = (ProxiedKafkaContainer) new ProxiedKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.1.2"))
+                    .withExposedPorts(exposedKafkaPort)
+                    .withNetwork(network);
+
+            toxiproxy = new ToxiproxyContainer(DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.5.0"))
+                    .withNetwork(network);
+
+            toxiproxy.start();
+            kafkaProxy = toxiproxy.getProxy(kafka, exposedKafkaPort);
+            bootstrapServers = "PLAINTEXT://" + kafkaProxy.getContainerIpAddress() + ":" + kafkaProxy.getProxyPort();
+
+            kafka.start();
+        }
+        return kafka;
+    }
+
+    public static void stopProxiedKafka() {
+        if (toxiproxy != null)
+            toxiproxy.stop();
+        if (kafka != null)
+            kafka.stop();
+    }
+
+    /** Kafka advertises its connection to connected clients, therefore we must override this */
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/TestUtils.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/TestUtils.java
@@ -16,15 +16,11 @@
 package one.tomorrow.transactionaloutbox;
 
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 public class TestUtils {
 
@@ -55,12 +51,6 @@ public class TestUtils {
                 value.getBytes(),
                 headers
         );
-    }
-
-    public static void assertConsumedRecord(OutboxRecord outboxRecord, String headerKey, ConsumerRecord<String, byte[]> kafkaRecord) {
-        assertEquals(outboxRecord.getKey(), kafkaRecord.key());
-        assertEquals(new String(outboxRecord.getValue()), new String(kafkaRecord.value()));
-        assertArrayEquals(outboxRecord.getHeaders().get(headerKey).getBytes(), kafkaRecord.headers().lastHeader(headerKey).value());
     }
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
@@ -16,60 +16,56 @@
 package one.tomorrow.transactionaloutbox.service;
 
 import eu.rekawek.toxiproxy.model.toxic.Timeout;
-import kafka.server.KafkaConfig$;
-import kafka.server.KafkaServer;
 import one.tomorrow.transactionaloutbox.IntegrationTestConfig;
+import one.tomorrow.transactionaloutbox.KafkaTestSupport;
+import one.tomorrow.transactionaloutbox.ProxiedKafkaContainer;
 import one.tomorrow.transactionaloutbox.model.OutboxLock;
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.repository.OutboxRepository;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.flywaydb.test.FlywayTestExecutionListener;
 import org.flywaydb.test.annotation.FlywayTest;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.test.EmbeddedKafkaBroker;
-import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.StreamSupport;
 
 import static eu.rekawek.toxiproxy.model.ToxicDirection.DOWNSTREAM;
 import static one.tomorrow.transactionaloutbox.IntegrationTestConfig.DEFAULT_OUTBOX_LOCK_TIMEOUT;
+import static one.tomorrow.transactionaloutbox.KafkaTestSupport.*;
+import static one.tomorrow.transactionaloutbox.ProxiedKafkaContainer.bootstrapServers;
+import static one.tomorrow.transactionaloutbox.ProxiedKafkaContainer.kafkaProxy;
 import static one.tomorrow.transactionaloutbox.ProxiedPostgreSQLContainer.postgresProxy;
 import static one.tomorrow.transactionaloutbox.TestUtils.newHeaders;
 import static one.tomorrow.transactionaloutbox.TestUtils.newRecord;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SEQUENCE_NAME;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SOURCE_NAME;
 import static one.tomorrow.transactionaloutbox.commons.Longs.toLong;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.springframework.kafka.test.utils.KafkaTestUtils.producerProps;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = {
@@ -86,14 +82,13 @@ import static org.springframework.kafka.test.utils.KafkaTestUtils.producerProps;
 })
 @FlywayTest
 @SuppressWarnings("unused")
-public class OutboxProcessorIntegrationTest {
+public class OutboxProcessorIntegrationTest implements KafkaTestSupport<byte[]> {
 
+    public static final ProxiedKafkaContainer kafkaContainer = ProxiedKafkaContainer.startProxiedKafka();
     private static final String topic1 = "topicOPIT1";
     private static final String topic2 = "topicOPIT2";
-    @Rule
-    public EmbeddedKafkaRule kafkaRule = new EmbeddedKafkaRule(1, true, 5, topic1, topic2)
-            .brokerProperty(KafkaConfig$.MODULE$.ListenersProp(), "PLAINTEXT://127.0.0.1:34567");
-    private Consumer<String, byte[]> consumer;
+    private static final AtomicInteger processorIdx = new AtomicInteger(0);
+    private static Consumer<String, byte[]> consumer;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -108,18 +103,31 @@ public class OutboxProcessorIntegrationTest {
 
     private OutboxProcessor testee;
 
+    @BeforeAll
+    public static void beforeAll() {
+        createTopic(bootstrapServers, topic1, topic2);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (consumer != null)
+            consumer.close();
+    }
+
     @After
     public void afterTest() {
         testee.close();
-        if (consumer != null)
-            consumer.close();
+    }
+
+    private static String lockOwnerId() {
+        return "processor-" + processorIdx.incrementAndGet();
     }
 
     @Test
     public void should_ProcessNewRecords() {
         // given
         String eventSource = "test";
-        testee = new OutboxProcessor(repository, producerFactory(), Duration.ofMillis(50), DEFAULT_OUTBOX_LOCK_TIMEOUT, "processor", eventSource, beanFactory);
+        testee = new OutboxProcessor(repository, producerFactory(), Duration.ofMillis(50), DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactory);
 
         // when
         OutboxRecord record1 = newRecord(topic1, "key1", "value1", newHeaders("h1", "v1"));
@@ -127,7 +135,7 @@ public class OutboxProcessorIntegrationTest {
 
         // then
         ConsumerRecords<String, byte[]> records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals("Have records with keys: " + keys(records), 1, records.count());
         ConsumerRecord<String, byte[]> kafkaRecord = records.iterator().next();
         assertConsumedRecord(record1, "h1", eventSource, kafkaRecord);
 
@@ -137,15 +145,13 @@ public class OutboxProcessorIntegrationTest {
 
         // then
         records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
         kafkaRecord = records.iterator().next();
         assertConsumedRecord(record2, "h2", eventSource, kafkaRecord);
     }
 
-    private ConsumerRecords<String, byte[]> getAndCommitRecords() {
-        ConsumerRecords<String, byte[]> records = KafkaTestUtils.getRecords(consumer(), Duration.ofSeconds(10));
-        consumer().commitSync();
-        return records;
+    private List<String> keys(ConsumerRecords<String,byte[]> records) {
+        return StreamSupport.stream(records.spliterator(), false).map(ConsumerRecord::key).toList();
     }
 
     @Test
@@ -153,20 +159,19 @@ public class OutboxProcessorIntegrationTest {
         // given
         OutboxRecord record1 = newRecord(topic1, "key1", "value1", newHeaders("h1", "v1"));
         transactionalRepository.persist(record1);
-
-        shutdownKafkaServers();
+        kafkaProxy.setConnectionCut(true);
 
         // when
         Duration processingInterval = Duration.ofMillis(50);
         String eventSource = "test";
-        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, "processor", eventSource, beanFactory);
+        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactory);
 
         Thread.sleep(processingInterval.plusMillis(200).toMillis());
-        startKafkaServers();
+        kafkaProxy.setConnectionCut(false);
 
         // then
         ConsumerRecords<String, byte[]> records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
     }
 
     @Test
@@ -177,26 +182,26 @@ public class OutboxProcessorIntegrationTest {
 
         Duration processingInterval = Duration.ofMillis(50);
         String eventSource = "test";
-        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, "processor", eventSource, beanFactory);
+        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactory);
 
         // when
         ConsumerRecords<String, byte[]> records = getAndCommitRecords();
 
         // then
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
 
         // and when
-        shutdownKafkaServers();
+        kafkaProxy.setConnectionCut(true);
 
         OutboxRecord record2 = newRecord(topic2, "key2", "value2", newHeaders("h2", "v2"));
         transactionalRepository.persist(record2);
 
         Thread.sleep(processingInterval.plusMillis(200).toMillis());
-        startKafkaServers();
+        kafkaProxy.setConnectionCut(false);
 
         // then
         records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
         assertConsumedRecord(record2, "h2", eventSource, records.iterator().next());
     }
 
@@ -209,7 +214,7 @@ public class OutboxProcessorIntegrationTest {
         Duration processingInterval = Duration.ofMillis(50);
         Duration outboxLockTimeout = Duration.ofMillis(500);
         String eventSource = "test";
-        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, outboxLockTimeout, "processor", eventSource, beanFactory);
+        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, outboxLockTimeout, lockOwnerId(), eventSource, beanFactory);
 
         // when
         ConsumerRecords<String, byte[]> records = getAndCommitRecords();
@@ -269,7 +274,7 @@ public class OutboxProcessorIntegrationTest {
             }
         };
 
-        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, "processor", eventSource, beanFactoryWrapper);
+        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactoryWrapper);
 
         // when
         OutboxRecord record1 = newRecord(topic1, "key1", "value1", newHeaders("h1", "v1"));
@@ -277,7 +282,7 @@ public class OutboxProcessorIntegrationTest {
 
         // then
         ConsumerRecords<String, byte[]> records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
 
         // and when
         failAcquireOrRefreshLock.set(true);
@@ -290,7 +295,7 @@ public class OutboxProcessorIntegrationTest {
 
         // then
         records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
     }
 
     @Test
@@ -331,7 +336,7 @@ public class OutboxProcessorIntegrationTest {
             }
         };
 
-        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, "processor", eventSource, beanFactoryWrapper);
+        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactoryWrapper);
 
         // when
         OutboxRecord record1 = newRecord(topic1, "key1", "value1", newHeaders("h1", "v1"));
@@ -339,7 +344,7 @@ public class OutboxProcessorIntegrationTest {
 
         // then
         ConsumerRecords<String, byte[]> records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
 
         // and when
         failPreventLockStealing.set(true);
@@ -352,7 +357,7 @@ public class OutboxProcessorIntegrationTest {
 
         // then
         records = getAndCommitRecords();
-        assertThat(records.count(), is(1));
+        assertEquals(1, records.count());
     }
 
     private void assertConsumedRecord(OutboxRecord outboxRecord, String headerKey, String sourceHeaderValue, ConsumerRecord<String, byte[]> kafkaRecord) {
@@ -363,41 +368,13 @@ public class OutboxProcessorIntegrationTest {
         assertArrayEquals(sourceHeaderValue.getBytes(), kafkaRecord.headers().lastHeader(HEADERS_SOURCE_NAME).value());
     }
 
-    private DefaultKafkaProducerFactory producerFactory() {
-        return new DefaultKafkaProducerFactory(producerProps(embeddedKafka()));
-    }
-
-    private EmbeddedKafkaBroker embeddedKafka() {
-        return kafkaRule.getEmbeddedKafka();
-    }
-
-    private void startKafkaServers() {
-        for (KafkaServer kafkaServer : embeddedKafka().getKafkaServers()) {
-            kafkaServer.startup();
+    @Override
+    public Consumer<String, byte[]> consumer() {
+        if (consumer == null) {
+            consumer = createConsumer(bootstrapServers);
+            consumer.subscribe(Arrays.asList(topic1, topic2));
         }
-    }
-
-    private void shutdownKafkaServers() {
-        for (KafkaServer kafkaServer : embeddedKafka().getKafkaServers()) {
-            kafkaServer.shutdown();
-            kafkaServer.awaitShutdown();
-        }
-    }
-
-    private Consumer<String, byte[]> consumer() {
-        if (consumer == null)
-            setupConsumer();
         return consumer;
-    }
-
-    private void setupConsumer() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", embeddedKafka());
-        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-        DefaultKafkaConsumerFactory<String, byte[]> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
-        // use unique groupId, so that a new consumer does not get into conflicts with some previous one, which might not yet be fully shutdown
-        consumer = cf.createConsumer("testConsumer-" + System.currentTimeMillis(), "someClientIdSuffix");
-        embeddedKafka().consumeFromAllEmbeddedTopics(consumer);
     }
 
 }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorIntegrationTest.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -64,6 +65,7 @@ import static one.tomorrow.transactionaloutbox.TestUtils.newRecord;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SEQUENCE_NAME;
 import static one.tomorrow.transactionaloutbox.commons.KafkaHeaders.HEADERS_SOURCE_NAME;
 import static one.tomorrow.transactionaloutbox.commons.Longs.toLong;
+import static org.apache.kafka.clients.producer.ProducerConfig.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -164,7 +166,11 @@ public class OutboxProcessorIntegrationTest implements KafkaTestSupport<byte[]> 
         // when
         Duration processingInterval = Duration.ofMillis(50);
         String eventSource = "test";
-        testee = new OutboxProcessor(repository, producerFactory(), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactory);
+        Map<String, Object> producerProps = producerProps(bootstrapServers);
+        producerProps.put(REQUEST_TIMEOUT_MS_CONFIG, 5000);
+        producerProps.put(DELIVERY_TIMEOUT_MS_CONFIG, 5000);
+        producerProps.put(MAX_BLOCK_MS_CONFIG, 5000);
+        testee = new OutboxProcessor(repository, producerFactory(producerProps), processingInterval, DEFAULT_OUTBOX_LOCK_TIMEOUT, lockOwnerId(), eventSource, beanFactory);
 
         Thread.sleep(processingInterval.plusMillis(200).toMillis());
         kafkaProxy.setConnectionCut(false);


### PR DESCRIPTION
This gets rid of `EmbeddedKafkaRule` which uses `EmbeddedKafkaBroker`, and helps to transition to a new kafka-clients version (3.6.x, see #253), which is currently blocked due to incompatibilities with spring-kafka-test. E.g. https://github.com/tomorrow-one/transactional-outbox/actions/runs/7142357304/job/19451488844?pr=253 failed with
```
Caused by:
        java.lang.ExceptionInInitializerError: Exception java.lang.IllegalStateException: Failed to obtain TestUtils.createBrokerConfig method; client version: 3.6.1 [in thread "Test worker"]
            at org.springframework.kafka.test.EmbeddedKafkaBroker.<clinit>(EmbeddedKafkaBroker.java:154)
            at org.springframework.kafka.test.rule.EmbeddedKafkaRule.<init>(EmbeddedKafkaRule.java:60)
```