### PR TITLE
Upgrade to Spring 6.1 and Spring Boot 3.2

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -2,7 +2,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    val springVersion = "6.0.13"
+    val springVersion = "6.1.2"
 
     "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
     implementation("org.apache.kafka:kafka-clients:3.6.1")

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -2,7 +2,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    val springVersion = "6.0.13"
+    val springVersion = "6.1.2"
     val springDataVersion = "3.1.5"
     val kafkaVersion = "3.6.1"
     val springKafkaVersion = "3.0.12"

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -1,6 +1,10 @@
 
 // the version is set in parent/root build.gradle.kts
 
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf("-parameters"))
+}
+
 dependencies {
     val springVersion = "6.1.2"
     val springDataVersion = "3.2.1"

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -1,7 +1,7 @@
 // the version is set in parent/root build.gradle.kts
 
 dependencies {
-    val springVersion = "6.0.13"
+    val springVersion = "6.1.2"
     val kafkaVersion = "3.6.1"
     val springKafkaVersion = "3.0.12"
     val log4jVersion = "2.22.0"


### PR DESCRIPTION
This integrates the following PRs:
* #262 
* #264 
* #265 
* #268 

It also adds the compiler option `-parameters` to the reactive version to prevent the runtime error
```
IllegalStateException: Cannot set property id because no setter, no wither and it's not part of the persistence constructor
```
which could also be fixed by adding `@lombok.With` to `OutboxRecord.id`,
and (if `@lombok.With` would have been used as a fix) to prevent the next issue
```
org.springframework.data.mapping.MappingException: Parameter org.springframework.data.mapping.Parameter@f0db254e does not have a name
```

The first issue occurred also in [this build](https://github.com/tomorrow-one/transactional-outbox/actions/runs/7228060080/job/19696823732?pr=265) for PR #265 and was once reported with issue #252

Note, that it's not entirely clear which change in Spring or R2DBC
exactly caused this new issue, we only see that it's needed. Maybe it's
also somehow related to issue #234