### PR TITLE
Fix #282: Support disabled auto-commit

### DIFF
--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
@@ -24,6 +24,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -80,6 +81,7 @@ public class OutboxRepository {
         return args;
     }
 
+    @Transactional
     public void updateProcessed(Long id, Instant processed) {
         jdbcTemplate.update("update outbox_kafka set processed = ? where id = ?", Timestamp.from(processed), id);
     }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/IntegrationTestConfig.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/IntegrationTestConfig.java
@@ -44,6 +44,7 @@ public class IntegrationTestConfig {
         dataSource.setUrl(postgresqlContainer.getJdbcUrl());
         dataSource.setUsername(postgresqlContainer.getUsername());
         dataSource.setPassword(postgresqlContainer.getPassword());
+        dataSource.setDefaultAutoCommit(false);
 
         return dataSource;
     }

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepositoryIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/repository/OutboxLockRepositoryIntegrationTest.java
@@ -28,6 +28,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Duration;
 import java.util.List;
@@ -59,10 +61,14 @@ class OutboxLockRepositoryIntegrationTest {
     private OutboxLockRepository testee;
     @Autowired
     private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
 
     @AfterEach
     public void cleanUp() {
-        jdbcTemplate.execute("delete from outbox_kafka_lock");
+        new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+                jdbcTemplate.execute("delete from outbox_kafka_lock")
+        );
     }
 
     @Test


### PR DESCRIPTION
If an application is configured with disabled auto-commit for the db driver / pool, the `processed` property of outbox records is not updated after a record was sent to kafka - because the update is rolled back instead of being is committed.

The fix is to add the `@Transactional` annotation to the `updateProcessed` method. Note that in fact is was there when jpa was used - because there it was definitely needed. With the transition to spring-jdbc it seemed as if the `@Transactional` is not needed - but this was only true for enabled auto-commit (which is the default for postgres).