### PR TITLE
Fix #304: Expose `active` property, add automatic cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ public class Cleaner {
 }
 ```
 
+**Note:** if you don't use a clustered job scheduling so that all instances would run this (maybe concurrently) you can also check `OutboxProcessor.isActive()` as a guard for performing the cleanup.
+
 ## How-To Release
 
 To release a new version follow this step

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxProcessor.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxProcessor.java
@@ -15,6 +15,7 @@
  */
 package one.tomorrow.transactionaloutbox.reactive.service;
 
+import lombok.Getter;
 import one.tomorrow.transactionaloutbox.commons.Longs;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxRepository;
@@ -64,6 +65,7 @@ public class OutboxProcessor {
 	private final byte[] eventSource;
 	private final int batchSize;
 	private KafkaProducer<String, byte[]> producer;
+    @Getter
 	private boolean active;
 	private Instant lastLockAckquisitionAttempt;
 

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -20,7 +20,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-    testImplementation("org.mockito:mockito-all:1.10.19")
+    testImplementation("org.mockito:mockito-core:5.11.0")
+    testImplementation("org.awaitility:awaitility:4.2.1")
 
     testImplementation("org.flywaydb:flyway-database-postgresql:10.10.0")
     testImplementation("org.flywaydb.flyway-test-extensions:flyway-spring-test:10.0.0")

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/repository/OutboxRepository.java
@@ -124,6 +124,7 @@ public class OutboxRepository {
      * @param deleteOlderThan the point in time until the processed entities shall be kept
      * @return amount of deleted rows
      */
+    @Transactional
     public int deleteOutboxRecordByProcessedNotNullAndProcessedIsBefore(Instant deleteOlderThan) {
         return jdbcTemplate.update(
                 "DELETE FROM outbox_kafka WHERE processed IS NOT NULL AND processed < ?",

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -15,7 +15,9 @@
  */
 package one.tomorrow.transactionaloutbox.service;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Value;
 import one.tomorrow.transactionaloutbox.commons.Longs;
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.repository.OutboxLockRepository;
@@ -47,6 +49,15 @@ public class OutboxProcessor {
         KafkaProducer<String, byte[]> createKafkaProducer();
     }
 
+    /** If provided, the outbox will be cleaned up in the given interval, i.e. outbox records will be
+     * deleted if they were processed before `ǹow - retention`. */
+    @Value
+    @Builder
+    public static class CleanupSettings {
+        Duration interval;
+        Duration retention;
+    }
+
     private static final int BATCH_SIZE = 100;
 
     private static final Logger logger = LoggerFactory.getLogger(OutboxProcessor.class);
@@ -57,6 +68,7 @@ public class OutboxProcessor {
     private final KafkaProducerFactory producerFactory;
     private final Duration processingInterval;
     private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService cleanupExecutor;
     private final byte[] eventSource;
     private KafkaProducer<String, byte[]> producer;
     @Getter
@@ -64,6 +76,7 @@ public class OutboxProcessor {
     private Instant lastLockAckquisitionAttempt;
 
     private ScheduledFuture<?> schedule;
+    private ScheduledFuture<?> cleanupSchedule;
 
     public OutboxProcessor(
             OutboxRepository repository,
@@ -72,6 +85,18 @@ public class OutboxProcessor {
             Duration lockTimeout,
             String lockOwnerId,
             String eventSource,
+            AutowireCapableBeanFactory beanFactory) {
+        this(repository, producerFactory, processingInterval, lockTimeout, lockOwnerId, eventSource, null, beanFactory);
+    }
+
+    public OutboxProcessor(
+            OutboxRepository repository,
+            KafkaProducerFactory producerFactory,
+            Duration processingInterval,
+            Duration lockTimeout,
+            String lockOwnerId,
+            String eventSource,
+            CleanupSettings cleanupSettings,
             AutowireCapableBeanFactory beanFactory) {
         logger.info("Starting outbox processor with lockOwnerId {}, source {} and processing interval {} ms and producer factory {}",
                 lockOwnerId, eventSource, processingInterval.toMillis(), producerFactory);
@@ -88,6 +113,20 @@ public class OutboxProcessor {
         executor = Executors.newSingleThreadScheduledExecutor();
 
         tryLockAcquisition();
+
+        cleanupExecutor = cleanupSettings != null ? setupCleanupSchedule(repository, cleanupSettings) : null;
+    }
+
+    private ScheduledExecutorService setupCleanupSchedule(OutboxRepository repository, CleanupSettings cleanupSettings) {
+        final ScheduledExecutorService es = Executors.newSingleThreadScheduledExecutor();
+        cleanupSchedule = es.scheduleAtFixedRate(() -> {
+            if (active) {
+                Instant processedBefore = now().minus(cleanupSettings.getRetention());
+                logger.info("Cleaning up outbox records processed before {}", processedBefore);
+                repository.deleteOutboxRecordByProcessedNotNullAndProcessedIsBefore(processedBefore);
+            }
+        }, 0, cleanupSettings.getInterval().toMillis(), MILLISECONDS);
+        return es;
     }
 
     private void scheduleProcessing() {
@@ -110,6 +149,12 @@ public class OutboxProcessor {
         if (schedule != null)
             schedule.cancel(false);
         executor.shutdown();
+
+        if (cleanupSchedule != null)
+            cleanupSchedule.cancel(false);
+        if (cleanupExecutor != null)
+            cleanupExecutor.shutdown();
+
         producer.close();
         if (active)
             lockService.releaseLock(lockOwnerId);

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxProcessor.java
@@ -15,6 +15,7 @@
  */
 package one.tomorrow.transactionaloutbox.service;
 
+import lombok.Getter;
 import one.tomorrow.transactionaloutbox.commons.Longs;
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.repository.OutboxLockRepository;
@@ -58,6 +59,7 @@ public class OutboxProcessor {
     private final ScheduledExecutorService executor;
     private final byte[] eventSource;
     private KafkaProducer<String, byte[]> producer;
+    @Getter
     private boolean active;
     private Instant lastLockAckquisitionAttempt;
 

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/OutboxProcessorTest.java
@@ -23,12 +23,10 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 
 import java.time.Duration;
@@ -40,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
@@ -141,18 +138,11 @@ public class OutboxProcessorTest {
     }
 
     @NotNull
-    private static Matcher<ProducerRecord<String, byte[]>> matching(OutboxRecord record) {
-        return new BaseMatcher<>() {
-            @Override
-            public void describeTo(Description description) {
-            }
-
-            @Override
-            public boolean matches(Object item) {
-                if (item == null)
-                    return false;
-                return Objects.equals(((ProducerRecord<String, byte[]>) item).key(), record.getKey());
-            }
+    private static ArgumentMatcher<ProducerRecord<String, byte[]>> matching(OutboxRecord record) {
+        return item -> {
+            if (item == null)
+                return false;
+            return Objects.equals(item.key(), record.getKey());
         };
     }
 


### PR DESCRIPTION
This PR addresses issue #304:

* Expose `OutboxProcessor.active` property
    
    So that external scheduling of the cleanup could take that into account
    to prevent parallel cleanup jobs (according to the first option stated
    in issue #304).

* Add automatic cleanup of processed outbox records
    
    This is implemented in a backwards compatible manner, i.e. existing
    integrations would have to be adjusted to use automatic cleanup.
    
    The cleanup is done by the active instance holding the lock. It's using
    a separate executor/scheduler, so that outbox processing cannot be
    negatively affected / blocked by the cleanup.

mockito in the classic spring module had to be updated to be compatible with awaitility (prevent conflicts with different hamcrest versions).