### PR TITLE
Update protobuf to 3.25.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     id("signing")
 }
 
-val protobufVersion by extra("3.21.9")
+val protobufVersion by extra("3.25.5")
 
 subprojects {
     apply(plugin = "java-library")


### PR DESCRIPTION
The update to protobuf 3.25.5 fixes the CVE-2024-7254

* https://nvd.nist.gov/vuln/detail/CVE-2024-7254
* https://github.com/advisories/GHSA-735f-pc8j-v9w8