### PR TITLE
Add tracing context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Depending on your application add one of the following libraries as dependency t
 
 | Spring Version | Spring Boot Version | outbox-kafka-spring Version | outbox-kafka-spring-reactive Version |
 |----------------|---------------------|-----------------------------|--------------------------------------|
-| 6.1.x          | 3.2.x               | 3.3.x                       | 3.2.x                                |
+| 6.2.x          | 3.4.x               | 3.5.x                       | 3.4.x                                |
+| 6.1.x          | 3.2.x - 3.3.x       | 3.3.x - 3.4.x               | 3.2.x - 3.3.x                        |
 | 6.0.x          | 3.1.x               | 2.0.x - 3.2.x               | 2.0.x - 3.1.x                        |
 | 5.x.x          | 2.x.x               | 1.2.x                       | 1.1.x                                |
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ migration scenarios. You'll specify which value for `x-source` shall be used.
 * `x-value-type` is set to the fully-qualified name of the protobuf message (within the proto language's namespace) if the `ProtobufOutboxService` is used.
   Consumers can use this header to select the appropriate deserializer / protobuf message type to parse the received data/payload.
 
+If tracing is used, tracing information is propagated via message headers (see also [Tracing](#tracing) for more information).  
+
 To allow operation in a service running with multiple instances, a lock is managed using the database, so that only one of the instances
 processes the outbox and publishes messages. All instances monitor that lock, and one of the instances will take over the lock when
 the lock-holding instance crashed (or is stuck somehow and does no longer refresh the lock).
@@ -108,6 +110,7 @@ public class TransactionalOutboxConfig {
     public OutboxProcessor outboxProcessor(
                 OutboxRepository repository,
                 Map<String, Object> producerProps,
+                TracingService tracingService,
                 AutowireCapableBeanFactory beanFactory
     ) {
         return new OutboxProcessor(
@@ -118,6 +121,7 @@ public class TransactionalOutboxConfig {
                 lockOwnerId,
                 eventSource,
                 cleanupSettings,
+                tracingService,
                 beanFactory
         );
     }
@@ -146,6 +150,7 @@ public class TransactionalOutboxConfig {
 * `String eventSource`: used as value for the `x-source` header set for a message published to Kafka
 * `CleanupSettings cleanupSettings`: specifies the interval for cleaning up the outbox and the retention time for processed records, i.e. how long to keep processed records before deleting them. Set `cleanupSettings` to `null` if you prefer manual or no cleanup at all. See also [How to house keep your outbox table](#how-to-house-keep-your-outbox-table) below.
 * `Map<String, Object> producerProps`: the properties used to create the `KafkaProducer` (contains e.g. `bootstrap.servers` etc)
+* `TracingService tracingService`: if [micrometer-tracing](https://docs.micrometer.io/tracing/reference/index.html) is on the classpath, our `MicrometerTracingService` bean will be used, otherwise it will fall back to `NoopTracingService`. You can also provide your own implementation of our `TracingService` interface. For more details on tracing [see below](#tracing).
 * `AutowireCapableBeanFactory beanFactory`: used to create the lock service (`OutboxLockService`)
 
 
@@ -171,7 +176,8 @@ public class TransactionalOutboxConfig {
     public OutboxProcessor outboxProcessor(
             OutboxRepository repository,
             OutboxLockService lockService,
-            Map<String, Object> producerProps
+            Map<String, Object> producerProps,
+            TracingService tracingService
     ) {
         return new OutboxProcessor(
                 repository,
@@ -181,7 +187,8 @@ public class TransactionalOutboxConfig {
                 outboxLockTimeout,
                 lockOwnerId,
                 eventSource,
-                cleanupSettings
+                cleanupSettings,
+                tracingService
         );
     }
 
@@ -244,6 +251,24 @@ public Mono<OutboxRecord> doSomething(String name) {
 
 }
 ```
+
+### Tracing
+
+If you have tracing in place you're probably interested in getting the trace context propagated with Kafka messages as well.
+We provide tracing context propagation out of the box for [micrometer-tracing](https://docs.micrometer.io/tracing/reference/index.html). If you're using something else you can provide your own implementation of the `TracingService` interface (for inspiration see `MicrometerTracingService`). If micrometer-tracing is not on the classpath, by default the `NoopTracingService` bean will be used as implementation.
+
+The tracing context is propagated if there's an active tracing context when `OutboxService.saveForPublishing` is invoked.
+If this is the case, the following will be provided:
+* A span for the message in the transactional-outbox is created (with start timestamp set to the time 
+  when the outbox record was created, and end timestamp set to the time when it's processed and sent to Kafka)
+* Another span is created for sending the message to Kafka (start timestamp is the time when the `ProducerRecord` 
+  is created, end timestamp is set when message sending got confirmed)
+* Tracing headers are added to the Kafka message (using [Propagator.inject](https://javadoc.io/static/io.micrometer/micrometer-tracing/1.5.0-M3/io/micrometer/tracing/propagation/Propagator.html#inject(io.micrometer.tracing.TraceContext,java.lang.Object,io.micrometer.tracing.propagation.Propagator.Setter))), which can be extracted via
+[Propagator.extract](https://javadoc.io/static/io.micrometer/micrometer-tracing/1.5.0-M3/io/micrometer/tracing/propagation/Propagator.html#extract(java.lang.Object,io.micrometer.tracing.propagation.Propagator.Getter)) on consumer side to continue or link the trace.
+
+With the implementation for micrometer-tracing we rely on the related config btw, e.g. regarding sampling probability or tracing protocol W3C/B3.
+
+You might also want to check the [Spring Boot docs for tracing](https://javadoc.io/static/io.micrometer/micrometer-tracing/1.5.0-M3/io/micrometer/tracing/propagation/Propagator.html#extract(java.lang.Object,io.micrometer.tracing.propagation.Propagator.Getter)).
 
 ### How-To re-publish a message
 

--- a/commons/src/main/java/one/tomorrow/transactionaloutbox/commons/Maps.java
+++ b/commons/src/main/java/one/tomorrow/transactionaloutbox/commons/Maps.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.commons;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Maps {
+
+    public static Map<String, String> merge(Map<String, String> map1, Map<String, String> map2) {
+        if (isNullOrEmpty(map1))
+            return map2;
+        if (isNullOrEmpty(map2))
+            return map1;
+        Map<String, String> result = new HashMap<>(map1);
+        result.putAll(map2);
+        return result;
+    }
+
+    public static boolean isNullOrEmpty(Map<?, ?> map) {
+        return map == null || map.isEmpty();
+    }
+
+}

--- a/outbox-kafka-spring-reactive/build.gradle.kts
+++ b/outbox-kafka-spring-reactive/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
     implementation("org.slf4j:slf4j-api:2.0.17")
     implementation("javax.annotation:javax.annotation-api:1.3.2")
     implementation(project(":commons"))
+    implementation(platform("io.micrometer:micrometer-tracing-bom:1.4.4"))
+    compileOnly("io.micrometer:micrometer-tracing")
 
     // testing
     testImplementation(testFixtures(project(":commons")))
@@ -47,4 +49,5 @@ dependencies {
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
     testImplementation("org.apache.commons:commons-dbcp2:2.13.0")
+    testImplementation("io.micrometer:micrometer-tracing-test")
 }

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/tracing/MicrometerTracingService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/tracing/MicrometerTracingService.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import lombok.AllArgsConstructor;
+import one.tomorrow.transactionaloutbox.commons.spring.ConditionalOnClass;
+import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@ConditionalOnClass(Tracer.class)
+@Service
+@Primary // if this is not good enough, NoopTracingService could use our own implementation of @ConditionalOnMissingBean
+@AllArgsConstructor
+public class MicrometerTracingService implements TracingService {
+
+    static final String TO_PREFIX = "To_";
+
+    private final Tracer tracer;
+    private final Propagator propagator;
+
+    @Override
+    public Map<String, String> tracingHeadersForOutboxRecord() {
+        TraceContext context = tracer.currentTraceContext().context();
+        if (context == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new HashMap<>();
+        propagator.inject(
+                context,
+                result,
+                (map, k, v) -> map.put(INTERNAL_PREFIX + k, v)
+        );
+        return result;
+    }
+
+    @Override
+    public TraceOutboxRecordProcessingResult traceOutboxRecordProcessing(OutboxRecord outboxRecord) {
+        Map<String, String> headers = outboxRecord.getHeadersAsMap();
+        Set<Entry<String, String>> headerEntries = headers.entrySet();
+        boolean containsTraceInfo = headerEntries.stream().anyMatch(e -> e.getKey().startsWith(INTERNAL_PREFIX));
+        if (!containsTraceInfo) {
+            return new HeadersOnlyTraceOutboxRecordProcessingResult(headers);
+        }
+
+        // This creates a new span with the same trace ID as the parent span
+        Span outboxSpan = propagator.extract(headers, (map, k) -> map.get(INTERNAL_PREFIX + k))
+                .name("transactional-outbox")
+                .startTimestamp(outboxRecord.getCreated().toEpochMilli(), TimeUnit.MILLISECONDS)
+                .start();
+        outboxSpan.end();
+
+        Map<String, String> newHeaders = headerEntries.stream()
+                .filter(entry -> !entry.getKey().startsWith(INTERNAL_PREFIX))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        // the span for publishing to Kafka - this span will be propagated via Kafka, and could be
+        // referenced by consumers via "follows_from" relationship or set as parent span
+        Span processingSpan = tracer.spanBuilder()
+                .setParent(outboxSpan.context())
+                .name(TO_PREFIX + outboxRecord.getTopic()) // provides better readability in the UI
+                .kind(Span.Kind.PRODUCER)
+                .start();
+
+        propagator.inject(processingSpan.context(), newHeaders, Map::put);
+
+        return new TraceOutboxRecordProcessingResult(newHeaders) {
+            @Override
+            public void publishCompleted() {
+                processingSpan.end();
+            }
+            @Override
+            public void publishFailed(Throwable t) {
+                processingSpan.error(t);
+            }
+        };
+    }
+
+}

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/tracing/NoopTracingService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/tracing/NoopTracingService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A no-op implementation of the {@link TracingService} interface. The MicrometerTracingService
+ * should be preferred if micrometer-tracing is available on the classpath, therefore it's annotated
+ * with {@code @Primary}. Alternatively, we could use our own implementation of {@code @ConditionalOnMissingBean}
+ * and use this class as the default/fallback implementation.
+ */
+@Service
+public class NoopTracingService implements TracingService {
+
+    @Override
+    public Map<String, String> tracingHeadersForOutboxRecord() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public TraceOutboxRecordProcessingResult traceOutboxRecordProcessing(OutboxRecord outboxRecord) {
+        return new HeadersOnlyTraceOutboxRecordProcessingResult(outboxRecord.getHeadersAsMap());
+    }
+
+}

--- a/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/tracing/TracingService.java
+++ b/outbox-kafka-spring-reactive/src/main/java/one/tomorrow/transactionaloutbox/reactive/tracing/TracingService.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import lombok.Data;
+import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
+
+import java.util.Map;
+
+public interface TracingService {
+
+    String INTERNAL_PREFIX = "_internal_:";
+
+    /**
+     * Extracts the tracing headers from the current context and returns them as a map.
+     * If tracing is not active, an empty map is returned.
+     * <p>
+     *  This is meant to be used when creating an outbox record, to store the tracing headers with the record.
+     * </p>
+     */
+    Map<String, String> tracingHeadersForOutboxRecord();
+
+    /**
+     * Extracts the tracing headers (as created via {@link #tracingHeadersForOutboxRecord()}) from the outbox record
+     * to create a span for the time spent in the outbox.<br/>
+     * A new span is started for the processing and publishing to Kafka, and headers to publish to Kafka are returned.
+     * The span must be completed once the message is published to Kafka.
+     */
+    TraceOutboxRecordProcessingResult traceOutboxRecordProcessing(OutboxRecord outboxRecord);
+
+    @Data
+    abstract class TraceOutboxRecordProcessingResult {
+
+        private final Map<String, String> headers;
+
+        /** Must be invoked once the outbox record was successfully sent to Kafka */
+        public abstract void publishCompleted();
+        /** Must be invoked if the outbox record could not be sent to Kafka */
+        public abstract void publishFailed(Throwable t);
+
+    }
+
+    class HeadersOnlyTraceOutboxRecordProcessingResult extends TraceOutboxRecordProcessingResult {
+        public HeadersOnlyTraceOutboxRecordProcessingResult(Map<String, String> headers) {
+            super(headers);
+        }
+
+        @Override
+        public void publishCompleted() {
+            // no-op
+        }
+
+        @Override
+        public void publishFailed(Throwable t) {
+            // no-op
+        }
+    }
+
+}

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/KafkaTestSupport.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/KafkaTestSupport.java
@@ -18,6 +18,7 @@ package one.tomorrow.transactionaloutbox.reactive;
 import one.tomorrow.transactionaloutbox.commons.CommonKafkaTestSupport;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.reactive.service.DefaultKafkaProducerFactory;
+import one.tomorrow.transactionaloutbox.reactive.tracing.TracingService;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import java.util.Map;
@@ -46,9 +47,10 @@ public interface KafkaTestSupport extends CommonKafkaTestSupport<byte[]> {
                 "OutboxRecord id and " + HEADERS_SEQUENCE_NAME + " headers do not match"
         );
         assertArrayEquals(sourceHeaderValue.getBytes(), kafkaRecord.headers().lastHeader(HEADERS_SOURCE_NAME).value());
-        outboxRecord.getHeadersAsMap().forEach((key, value) ->
-                assertArrayEquals(value.getBytes(), kafkaRecord.headers().lastHeader(key).value())
-        );
+        outboxRecord.getHeadersAsMap().forEach((key, value) -> {
+            if (!key.startsWith(TracingService.INTERNAL_PREFIX))
+                assertArrayEquals(value.getBytes(), kafkaRecord.headers().lastHeader(key).value());
+        });
         assertEquals(outboxRecord.getKey(), kafkaRecord.key());
         assertArrayEquals(outboxRecord.getValue(), kafkaRecord.value());
     }

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxServiceIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/OutboxServiceIntegrationTest.java
@@ -15,12 +15,19 @@
  */
 package one.tomorrow.transactionaloutbox.reactive.service;
 
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micrometer.tracing.test.simple.SimpleTracer;
 import one.tomorrow.transactionaloutbox.reactive.AbstractIntegrationTest;
 import one.tomorrow.transactionaloutbox.reactive.IntegrationTestConfig;
+import one.tomorrow.transactionaloutbox.reactive.TestUtils;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxLock;
 import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxRepository;
+import one.tomorrow.transactionaloutbox.reactive.tracing.MicrometerTracingIntegrationTestConfig;
 import org.flywaydb.test.annotation.FlywayTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -35,8 +42,8 @@ import reactor.test.StepVerifier;
 
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static one.tomorrow.transactionaloutbox.reactive.tracing.TracingService.INTERNAL_PREFIX;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
@@ -45,7 +52,8 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
         OutboxLock.class,
         OutboxLockService.class,
         OutboxService.class,
-        IntegrationTestConfig.class
+        IntegrationTestConfig.class,
+        MicrometerTracingIntegrationTestConfig.class
 })
 @FlywayTest
 @SuppressWarnings({"unused", "ConstantConditions"})
@@ -59,9 +67,13 @@ class OutboxServiceIntegrationTest extends AbstractIntegrationTest {
     private OutboxRepository repository;
     @Autowired
     private TransactionalOperator rxtx;
+    @Autowired
+    private SimpleTracer tracer;
+    @Autowired
+    private Propagator tracingPropagator;
 
     @AfterEach
-    public void cleanUp() {
+    void cleanUp() {
         repository.deleteAll().block();
     }
 
@@ -114,6 +126,44 @@ class OutboxServiceIntegrationTest extends AbstractIntegrationTest {
         assertThat(foundRecord, is(notNullValue()));
         Map.Entry<String, String> entry = additionalHeader.entrySet().iterator().next();
         assertThat(foundRecord.getHeadersAsMap(), hasEntry(entry.getKey(), entry.getValue()));
+    }
+
+    @Test
+    void should_save_withTracingHeaders() {
+        // given
+        String message = "foo";
+        Map<String, String> additionalHeader = TestUtils.randomBoolean()
+                ? Map.of("key", "value")
+                : Map.of();
+
+        // when
+        Span span = tracer.nextSpan().name("test-span").start();
+        OutboxRecord savedRecord;
+        try (Tracer.SpanInScope ignored = tracer.withSpan(span)) {
+            // when
+            savedRecord = testee.saveForPublishing("topic", "key", message.getBytes(), additionalHeader)
+                    .as(rxtx::transactional)
+                    .block();
+        } finally {
+            span.end();
+        }
+
+        // then
+        assertThat(savedRecord.getId(), is(notNullValue()));
+
+        OutboxRecord foundRecord = repository.findById(savedRecord.getId()).block();
+        assertThat(foundRecord, is(notNullValue()));
+
+        Map<String, String> headers = foundRecord.getHeadersAsMap();
+        additionalHeader.forEach((key, value) ->
+                assertThat(headers, hasEntry(key, value))
+        );
+
+        TraceContext extractedSpan = tracingPropagator.extract(headers, (map, k) -> map.get(INTERNAL_PREFIX + k))
+                .start()
+                .context();
+        assertThat(extractedSpan.traceId(), is(equalTo(span.context().traceId())));
+        assertThat(extractedSpan.parentId(), is(equalTo(span.context().spanId())));
     }
 
 }

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxServiceIntegrationTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/service/ProtobufOutboxServiceIntegrationTest.java
@@ -22,6 +22,7 @@ import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.reactive.repository.OutboxRepository;
 import one.tomorrow.transactionaloutbox.reactive.test.Sample.SomethingHappened;
+import one.tomorrow.transactionaloutbox.reactive.tracing.MicrometerTracingIntegrationTestConfig;
 import org.flywaydb.test.annotation.FlywayTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,8 @@ import static org.hamcrest.collection.IsMapContaining.hasKey;
         OutboxLockService.class,
         OutboxService.class,
         ProtobufOutboxService.class,
-        IntegrationTestConfig.class
+        IntegrationTestConfig.class,
+        MicrometerTracingIntegrationTestConfig.class
 })
 @FlywayTest
 @SuppressWarnings({"unused", "ConstantConditions"})

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/MicrometerTracingIntegrationTestConfig.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/MicrometerTracingIntegrationTestConfig.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.handler.TracingObservationHandler;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Hooks;
+
+@Configuration
+public class MicrometerTracingIntegrationTestConfig {
+
+    static {
+        Hooks.enableAutomaticContextPropagation();
+    }
+
+    @Bean
+    public TracingObservationHandler<Observation.Context> tracingObservationHandler(Tracer tracer) {
+        return new DefaultTracingObservationHandler(tracer);
+    }
+
+    @Bean
+    public ObservationRegistry observationRegistry(TracingObservationHandler<Observation.Context> tracingObservationHandler) {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(tracingObservationHandler);
+
+        // From https://docs.micrometer.io/micrometer/reference/observation/instrumenting.html#instrumentation_of_reactive_libraries:
+        // Starting from Micrometer 1.10.8 you need to set your registry on this singleton instance of OTLA
+        ObservationThreadLocalAccessor.getInstance().setObservationRegistry(registry);
+
+        return registry;
+    }
+
+    @Bean
+    public SimpleTracer simpleTracer() {
+        return new SimpleTracer();
+    }
+
+    @Bean
+    public Propagator propagator(SimpleTracer tracer) {
+        return new SimplePropagator(tracer);
+    }
+
+    @Bean
+    public TracingService tracingService(SimpleTracer tracer, Propagator propagator) {
+        return new MicrometerTracingService(tracer, propagator);
+    }
+
+}

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/MicrometerTracingServiceTest.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/MicrometerTracingServiceTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer.SpanInScope;
+import io.micrometer.tracing.test.simple.SimpleSpan;
+import io.micrometer.tracing.test.simple.SimpleTraceContext;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
+import one.tomorrow.transactionaloutbox.reactive.tracing.TracingService.TraceOutboxRecordProcessingResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord.toJson;
+import static one.tomorrow.transactionaloutbox.reactive.tracing.SimplePropagator.TRACING_SPAN_ID;
+import static one.tomorrow.transactionaloutbox.reactive.tracing.SimplePropagator.TRACING_TRACE_ID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class MicrometerTracingServiceTest implements TracingAssertions {
+
+    private SimpleTracer tracer;
+    private MicrometerTracingService micrometerTracingService;
+
+    @BeforeEach
+    void setUp() {
+        tracer = new SimpleTracer();
+        micrometerTracingService = new MicrometerTracingService(tracer, new SimplePropagator(tracer));
+    }
+
+    @Test
+    void tracingHeadersForOutboxRecord_withoutActiveTraceContext_returnsEmptyMap() {
+        Map<String, String> headers = micrometerTracingService.tracingHeadersForOutboxRecord();
+        assertThat(headers, is(anEmptyMap()));
+    }
+
+    @Test
+    void tracingHeadersForOutboxRecord_withActiveTraceContext_returnsHeaders() {
+        Span span = tracer.nextSpan().name("test-span").start();
+        try (SpanInScope ignored = tracer.withSpan(span)) {
+            Map<String, String> headers = micrometerTracingService.tracingHeadersForOutboxRecord();
+            assertThat(headers, is(not(anEmptyMap())));
+            assertThat(headers.get("_internal_:" + TRACING_TRACE_ID), is(equalTo(span.context().traceId())));
+            assertThat(headers.get("_internal_:" + TRACING_SPAN_ID), is(equalTo(span.context().spanId())));
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void traceOutboxRecordProcessing_withValidOutboxRecord_createsAndEndsSpan() {
+        String traceId = "traceId1";
+        String spanId = "spanId1";
+        OutboxRecord outboxRecord = OutboxRecord.builder()
+                .created(Instant.now().minusMillis(42))
+                .headers(toJson(Map.of(
+                        "some", "header",
+                        "_internal_:" + TRACING_TRACE_ID, traceId,
+                        "_internal_:" + TRACING_SPAN_ID, spanId)))
+                .build();
+
+        TraceOutboxRecordProcessingResult result = micrometerTracingService.traceOutboxRecordProcessing(outboxRecord);
+
+        // verify recorded span for the outbox record in the transactional-outbox
+        assertThat(tracer.getSpans(), hasSize(2)); // one for the transactional-outbox and one for the processing to Kafka
+        SimpleSpan outboxSpan = tracer.getSpans().getFirst();
+        assertOutboxSpan(outboxSpan, traceId, spanId, outboxRecord);
+
+        // verify recorded span for the processing to Kafka
+        SimpleSpan processingSpan = tracer.getSpans().getLast();
+        SimpleTraceContext processingSpanContext = processingSpan.context();
+        assertProcessingSpan(processingSpanContext, traceId, outboxSpan.context().spanId());
+
+        // verify returned headers
+        Map<String, String> headers = result.getHeaders();
+        assertThat(headers, hasEntry("some", "header"));
+        assertThat(headers, hasEntry(TRACING_TRACE_ID, traceId));
+        assertThat(headers, hasEntry(TRACING_SPAN_ID, processingSpanContext.spanId()));
+
+        // verify that the processing span is ended correctly
+        // initially the end timespan is
+        assertThat(processingSpan.getEndTimestamp(), is(equalTo(Instant.ofEpochMilli(0L))));
+        Instant before = Instant.now().truncatedTo(MILLIS);
+        result.publishCompleted();
+        Instant after = Instant.now().truncatedTo(MILLIS);
+        assertThat(processingSpan.getEndTimestamp(), is(greaterThanOrEqualTo(before)));
+        assertThat(processingSpan.getEndTimestamp(), is(lessThanOrEqualTo(after)));
+    }
+
+    @Test
+    void traceOutboxRecordProcessing_withoutTraceHeaders_ignoresTracing() {
+        OutboxRecord outboxRecord = OutboxRecord.builder()
+                .created(Instant.now())
+                .headers(toJson(Map.of("some", "header")))
+                .build();
+
+        TraceOutboxRecordProcessingResult result = micrometerTracingService.traceOutboxRecordProcessing(outboxRecord);
+
+        assertThat(tracer.getSpans(), is(empty()));
+        Map<String, String> headers = result.getHeaders();
+        assertThat(headers, is(aMapWithSize(1)));
+        assertThat(headers.get("some"), is(equalTo("header")));
+    }
+
+}

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/SimplePropagator.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/SimplePropagator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micrometer.tracing.test.simple.SimpleSpanBuilder;
+import io.micrometer.tracing.test.simple.SimpleTraceContext;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class SimplePropagator implements Propagator {
+
+    public static final String TRACING_TRACE_ID = "traceId";
+    public static final String TRACING_SPAN_ID = "spanId";
+    private final SimpleTracer tracer;
+
+    @Override
+    @NotNull
+    public List<String> fields() {
+        return List.of(TRACING_TRACE_ID, TRACING_SPAN_ID);
+    }
+
+    @Override
+    public <C> void inject(TraceContext context, C carrier, Setter<C> setter) {
+        setter.set(carrier, TRACING_TRACE_ID, context.traceId());
+        setter.set(carrier, TRACING_SPAN_ID, context.spanId());
+    }
+
+    @Override
+    @NotNull
+    public <C> Span.Builder extract(@NotNull C carrier, Getter<C> getter) {
+        SimpleTraceContext traceContext = new SimpleTraceContext();
+
+        String traceId = getter.get(carrier, TRACING_TRACE_ID);
+        if (traceId != null)
+            traceContext.setTraceId(traceId);
+
+        String spanId = getter.get(carrier, TRACING_SPAN_ID);
+        if (spanId != null)
+            traceContext.setSpanId(spanId);
+
+        Span.Builder builder = new SimpleSpanBuilder(tracer);
+        builder.setParent(traceContext);
+        return builder;
+    }
+}

--- a/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/TracingAssertions.java
+++ b/outbox-kafka-spring-reactive/src/test/java/one/tomorrow/transactionaloutbox/reactive/tracing/TracingAssertions.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.reactive.tracing;
+
+import io.micrometer.tracing.test.simple.SimpleSpan;
+import io.micrometer.tracing.test.simple.SimpleTraceContext;
+import one.tomorrow.transactionaloutbox.reactive.model.OutboxRecord;
+
+import java.time.temporal.ChronoUnit;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+public interface TracingAssertions {
+
+    default void assertOutboxSpan(SimpleSpan outboxSpan, String traceId, String parentId, OutboxRecord outboxRecord) {
+        SimpleTraceContext outboxSpanContext = outboxSpan.context();
+        assertThat(outboxSpanContext.traceId(), is(equalTo(traceId)));
+        assertThat(outboxSpanContext.parentId(), is(equalTo(parentId)));
+        assertThat(outboxSpan.getStartTimestamp().truncatedTo(MILLIS), is(equalTo(outboxRecord.getCreated().truncatedTo(MILLIS))));
+        assertThat(outboxSpan.getEndTimestamp(), is(greaterThan(outboxRecord.getCreated())));
+        assertThat(outboxSpanContext.spanId(), is(notNullValue()));
+    }
+
+    default void assertProcessingSpan(SimpleTraceContext processingSpanContext, String traceId, String parentId) {
+        assertThat(processingSpanContext.traceId(), is(equalTo(traceId)));
+        assertThat(processingSpanContext.parentId(), is(equalTo(parentId)));
+        assertThat(processingSpanContext.spanId(), is(notNullValue()));
+    }
+
+}

--- a/outbox-kafka-spring/build.gradle.kts
+++ b/outbox-kafka-spring/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     val springVersion = "6.2.5"
     val kafkaVersion = "3.9.0"
     val log4jVersion = "2.24.3"
+    val slf4jVersion = "2.0.17"
 
     implementation("org.springframework:spring-context:$springVersion")
     implementation("org.springframework:spring-jdbc:$springVersion")
@@ -11,9 +12,11 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
     implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
     "protobufSupportImplementation"("com.google.protobuf:protobuf-java:${rootProject.extra["protobufVersion"]}")
-    implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation("org.slf4j:slf4j-api:$slf4jVersion")
     implementation("jakarta.annotation:jakarta.annotation-api:3.0.0")
     implementation(project(":commons"))
+    implementation(platform("io.micrometer:micrometer-tracing-bom:1.4.4"))
+    compileOnly("io.micrometer:micrometer-tracing")
 
     // testing
     testImplementation(testFixtures(project(":commons")))
@@ -28,5 +31,7 @@ dependencies {
 
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
+    testImplementation("org.slf4j:slf4j-simple:$slf4jVersion")
     testImplementation("org.apache.commons:commons-dbcp2:2.13.0")
+    testImplementation("io.micrometer:micrometer-tracing-test")
 }

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/service/OutboxService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 Tomorrow GmbH @ https://tomorrow.one
+ * Copyright 2023-2025 Tomorrow GmbH @ https://tomorrow.one
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,29 +18,36 @@ package one.tomorrow.transactionaloutbox.service;
 import lombok.AllArgsConstructor;
 import one.tomorrow.transactionaloutbox.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.repository.OutboxRepository;
+import one.tomorrow.transactionaloutbox.tracing.TracingService;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
 import java.util.Map;
+
+import static one.tomorrow.transactionaloutbox.commons.Maps.merge;
 
 @Service
 @AllArgsConstructor
 public class OutboxService {
 
     private OutboxRepository repository;
+    private TracingService tracingService;
 
     public OutboxRecord saveForPublishing(String topic, String key, byte[] value) {
         return saveForPublishing(topic, key, value, null);
     }
 
     public OutboxRecord saveForPublishing(String topic, String key, byte[] value, Map<String, String> headerMap) {
-        OutboxRecord record = OutboxRecord.builder()
+        Map<String, String> tracingHeaders = tracingService.tracingHeadersForOutboxRecord();
+        Map<String, String> headers = merge(headerMap, tracingHeaders);
+        OutboxRecord outboxRecord = OutboxRecord.builder()
                 .topic(topic)
                 .key(key)
                 .value(value)
-                .headers(headerMap)
+                .headers(headers)
                 .build();
-        repository.persist(record);
-        return record;
+        repository.persist(outboxRecord);
+        return outboxRecord;
     }
 
 }

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/tracing/MicrometerTracingService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/tracing/MicrometerTracingService.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.Tracer;
+import io.micrometer.tracing.propagation.Propagator;
+import lombok.AllArgsConstructor;
+import one.tomorrow.transactionaloutbox.commons.spring.ConditionalOnClass;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@ConditionalOnClass(Tracer.class)
+@Service
+@Primary // if this is not good enough, NoopTracingService could use our own implementation of @ConditionalOnMissingBean
+@AllArgsConstructor
+public class MicrometerTracingService implements TracingService {
+
+    static final String TO_PREFIX = "To_";
+
+    private final Tracer tracer;
+    private final Propagator propagator;
+
+    @Override
+    public Map<String, String> tracingHeadersForOutboxRecord() {
+        TraceContext context = tracer.currentTraceContext().context();
+        if (context == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new HashMap<>();
+        propagator.inject(
+                context,
+                result,
+                (map, k, v) -> map.put(INTERNAL_PREFIX + k, v)
+        );
+        return result;
+    }
+
+    @Override
+    public TraceOutboxRecordProcessingResult traceOutboxRecordProcessing(OutboxRecord outboxRecord) {
+        Set<Entry<String, String>> headerEntries = outboxRecord.getHeaders().entrySet();
+        boolean containsTraceInfo = headerEntries.stream().anyMatch(e -> e.getKey().startsWith(INTERNAL_PREFIX));
+        if (!containsTraceInfo) {
+            return new HeadersOnlyTraceOutboxRecordProcessingResult(outboxRecord.getHeaders());
+        }
+
+        // This creates a new span with the same trace ID as the parent span
+        Span outboxSpan = propagator.extract(outboxRecord.getHeaders(), (map, k) -> map.get(INTERNAL_PREFIX + k))
+                .name("transactional-outbox")
+                .startTimestamp(outboxRecord.getCreated().getTime(), TimeUnit.MILLISECONDS)
+                .start();
+        outboxSpan.end();
+
+        Map<String, String> newHeaders = headerEntries.stream()
+                .filter(entry -> !entry.getKey().startsWith(INTERNAL_PREFIX))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        // the span for publishing to Kafka - this span will be propagated via Kafka, and could be
+        // referenced by consumers via "follows_from" relationship or set as parent span
+        Span processingSpan = tracer.spanBuilder()
+                .setParent(outboxSpan.context())
+                .name(TO_PREFIX + outboxRecord.getTopic()) // provides better readability in the UI
+                .kind(Span.Kind.PRODUCER)
+                .start();
+
+        propagator.inject(processingSpan.context(), newHeaders, Map::put);
+
+        return new TraceOutboxRecordProcessingResult(newHeaders) {
+            @Override
+            public void publishCompleted() {
+                processingSpan.end();
+            }
+            @Override
+            public void publishFailed(Throwable t) {
+                processingSpan.error(t);
+            }
+        };
+    }
+
+}

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/tracing/NoopTracingService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/tracing/NoopTracingService.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A no-op implementation of the {@link TracingService} interface. The MicrometerTracingService
+ * should be preferred if micrometer-tracing is available on the classpath, therefore it's annotated
+ * with {@code @Primary}. Alternatively, we could use our own implementation of {@code @ConditionalOnMissingBean}
+ * and use this class as the default/fallback implementation.
+ */
+@Service
+public class NoopTracingService implements TracingService {
+
+    @Override
+    public Map<String, String> tracingHeadersForOutboxRecord() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public TraceOutboxRecordProcessingResult traceOutboxRecordProcessing(OutboxRecord outboxRecord) {
+        return new HeadersOnlyTraceOutboxRecordProcessingResult(outboxRecord.getHeaders());
+    }
+
+}

--- a/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/tracing/TracingService.java
+++ b/outbox-kafka-spring/src/main/java/one/tomorrow/transactionaloutbox/tracing/TracingService.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import lombok.Data;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+
+import java.util.Map;
+
+public interface TracingService {
+
+    String INTERNAL_PREFIX = "_internal_:";
+
+    /**
+     * Extracts the tracing headers from the current context and returns them as a map.
+     * If tracing is not active, an empty map is returned.
+     * <p>
+     *  This is meant to be used when creating an outbox record, to store the tracing headers with the record.
+     * </p>
+     */
+    Map<String, String> tracingHeadersForOutboxRecord();
+
+    /**
+     * Extracts the tracing headers (as created via {@link #tracingHeadersForOutboxRecord()}) from the outbox record
+     * to create a span for the time spent in the outbox.<br/>
+     * A new span is started for the processing and publishing to Kafka, and headers to publish to Kafka are returned.
+     * The span must be completed once the message is published to Kafka.
+     */
+    TraceOutboxRecordProcessingResult traceOutboxRecordProcessing(OutboxRecord outboxRecord);
+
+    @Data
+    abstract class TraceOutboxRecordProcessingResult {
+
+        private final Map<String, String> headers;
+
+        /** Must be invoked once the outbox record was successfully sent to Kafka */
+        public abstract void publishCompleted();
+        /** Must be invoked if the outbox record could not be sent to Kafka */
+        public abstract void publishFailed(Throwable t);
+
+    }
+
+    class HeadersOnlyTraceOutboxRecordProcessingResult extends TraceOutboxRecordProcessingResult {
+        public HeadersOnlyTraceOutboxRecordProcessingResult(Map<String, String> headers) {
+            super(headers);
+        }
+
+        @Override
+        public void publishCompleted() {
+            // no-op
+        }
+
+        @Override
+        public void publishFailed(Throwable t) {
+            // no-op
+        }
+    }
+
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/TestUtils.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/TestUtils.java
@@ -21,8 +21,15 @@ import org.jetbrains.annotations.NotNull;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 public class TestUtils {
+
+    private static final Random RANDOM = new Random();
+
+    public static boolean randomBoolean() {
+        return RANDOM.nextBoolean();
+    }
 
     @NotNull
     public static Map<String, String> newHeaders(String ... keyValue) {

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxUsageIntegrationTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/ProtobufOutboxUsageIntegrationTest.java
@@ -25,6 +25,7 @@ import one.tomorrow.transactionaloutbox.model.OutboxRecord;
 import one.tomorrow.transactionaloutbox.repository.OutboxLockRepository;
 import one.tomorrow.transactionaloutbox.repository.OutboxRepository;
 import one.tomorrow.transactionaloutbox.test.Sample.SomethingHappened;
+import one.tomorrow.transactionaloutbox.tracing.MicrometerTracingIntegrationTestConfig;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -64,7 +65,8 @@ import static org.junit.Assert.*;
         ProtobufOutboxService.class,
         SampleProtobufService.class,
         IntegrationTestConfig.class,
-        ProtobufOutboxUsageIntegrationTest.OutboxProcessorSetup.class
+        ProtobufOutboxUsageIntegrationTest.OutboxProcessorSetup.class,
+        MicrometerTracingIntegrationTestConfig.class
 })
 @TestExecutionListeners({
         DependencyInjectionTestExecutionListener.class,

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleService.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/service/SampleService.java
@@ -42,18 +42,19 @@ public class SampleService {
     public void doSomething(int id, String something) {
         // Here s.th. else would be done within the transaction, e.g. some entity created.
         // We record this fact with the event that shall be published to interested parties / consumers.
-        OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes());
-        logger.info("Stored event [{}] in outbox with id {} and key {}", something, record.getId(), record.getKey());
+        OutboxRecord outboxRecord = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes());
+        logger.info("Stored event [{}] in outbox with id {} and key {}", something, outboxRecord.getId(), outboxRecord.getKey());
     }
 
     @Transactional
-    public void doSomethingWithAdditionalHeaders(int id, String something, Header...headers) {
+    public OutboxRecord doSomethingWithAdditionalHeaders(int id, String something, Header...headers) {
         // Here s.th. else would be done within the transaction, e.g. some entity created.
         // We record this fact with the event that shall be published to interested parties / consumers.
         Map<String, String> headerMap = Arrays.stream(headers)
                 .collect(Collectors.toMap(Header::getKey, Header::getValue));
-        OutboxRecord record = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes(), headerMap);
-        logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", something, record.getId(), record.getKey(), record.getHeaders());
+        OutboxRecord outboxRecord = outboxService.saveForPublishing(topic1, String.valueOf(id), something.getBytes(), headerMap);
+        logger.info("Stored event [{}] in outbox with id {}, key {} and headers {}", something, outboxRecord.getId(), outboxRecord.getKey(), outboxRecord.getHeaders());
+        return outboxRecord;
     }
 
     @Getter

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/MicrometerTracingIntegrationTestConfig.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/MicrometerTracingIntegrationTestConfig.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import io.micrometer.tracing.propagation.Propagator;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MicrometerTracingIntegrationTestConfig {
+
+    @Bean
+    public SimpleTracer simpleTracer() {
+        return new SimpleTracer();
+    }
+
+    @Bean
+    public Propagator propagator(SimpleTracer tracer) {
+        return new SimplePropagator(tracer);
+    }
+
+    @Bean
+    public TracingService tracingService(SimpleTracer tracer, Propagator propagator) {
+        return new MicrometerTracingService(tracer, propagator);
+    }
+
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/MicrometerTracingServiceTest.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/MicrometerTracingServiceTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.Tracer.SpanInScope;
+import io.micrometer.tracing.test.simple.SimpleSpan;
+import io.micrometer.tracing.test.simple.SimpleTraceContext;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+import one.tomorrow.transactionaloutbox.tracing.TracingService.TraceOutboxRecordProcessingResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+
+import static java.lang.System.currentTimeMillis;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static one.tomorrow.transactionaloutbox.tracing.SimplePropagator.TRACING_SPAN_ID;
+import static one.tomorrow.transactionaloutbox.tracing.SimplePropagator.TRACING_TRACE_ID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MicrometerTracingServiceTest implements TracingAssertions {
+
+    private SimpleTracer tracer;
+    private MicrometerTracingService micrometerTracingService;
+
+    @BeforeEach
+    void setUp() {
+        tracer = new SimpleTracer();
+        micrometerTracingService = new MicrometerTracingService(tracer, new SimplePropagator(tracer));
+    }
+
+    @Test
+    void tracingHeadersForOutboxRecord_withoutActiveTraceContext_returnsEmptyMap() {
+        Map<String, String> headers = micrometerTracingService.tracingHeadersForOutboxRecord();
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    void tracingHeadersForOutboxRecord_withActiveTraceContext_returnsHeaders() {
+        Span span = tracer.nextSpan().name("test-span").start();
+        try (SpanInScope ignored = tracer.withSpan(span)) {
+            Map<String, String> headers = micrometerTracingService.tracingHeadersForOutboxRecord();
+            assertFalse(headers.isEmpty());
+            assertEquals(span.context().traceId(), headers.get("_internal_:" + TRACING_TRACE_ID));
+            assertEquals(span.context().spanId(), headers.get("_internal_:" + TRACING_SPAN_ID));
+        } finally {
+            span.end();
+        }
+    }
+
+    @Test
+    void traceOutboxRecordProcessing_withValidOutboxRecord_createsAndEndsSpan() {
+        OutboxRecord outboxRecord = new OutboxRecord();
+        String traceId = "traceId1";
+        String spanId = "spanId1";
+        outboxRecord.setHeaders(Map.of(
+                "some", "header",
+                "_internal_:" + TRACING_TRACE_ID, traceId,
+                "_internal_:" + TRACING_SPAN_ID, spanId));
+        outboxRecord.setCreated(new Timestamp(currentTimeMillis() - 42));
+
+        TraceOutboxRecordProcessingResult result = micrometerTracingService.traceOutboxRecordProcessing(outboxRecord);
+
+        // verify recorded span for the outbox record in the transactional-outbox
+        assertEquals(2, tracer.getSpans().size()); // one for the transactional-outbox and one for the processing to Kafka
+        SimpleSpan outboxSpan = tracer.getSpans().getFirst();
+        assertOutboxSpan(outboxSpan, traceId, spanId, outboxRecord);
+
+        // verify recorded span for the processing to Kafka
+        SimpleSpan processingSpan = tracer.getSpans().getLast();
+        SimpleTraceContext processingSpanContext = processingSpan.context();
+        assertProcessingSpan(processingSpanContext, traceId, outboxSpan.context().spanId());
+
+        // verify returned headers
+        Map<String, String> headers = result.getHeaders();
+        assertThat(headers, hasEntry("some", "header"));
+        assertThat(headers, hasEntry(TRACING_TRACE_ID, traceId));
+        assertThat(headers, hasEntry(TRACING_SPAN_ID, processingSpanContext.spanId()));
+
+        // verify that the processing span is ended correctly
+        // initially the end timespan is
+        assertEquals(Instant.ofEpochMilli(0L), processingSpan.getEndTimestamp());
+        Instant before = Instant.now().truncatedTo(MILLIS);
+        result.publishCompleted();
+        Instant after = Instant.now().truncatedTo(MILLIS);
+        assertThat(before, lessThanOrEqualTo(processingSpan.getEndTimestamp()));
+        assertThat(after, greaterThanOrEqualTo(processingSpan.getEndTimestamp()));
+    }
+
+    @Test
+    void traceOutboxRecordProcessing_withoutTraceHeaders_ignoresTracing() {
+        OutboxRecord outboxRecord = new OutboxRecord();
+        outboxRecord.setHeaders(Map.of("some", "header"));
+        outboxRecord.setCreated(new Timestamp(currentTimeMillis()));
+
+        TraceOutboxRecordProcessingResult result = micrometerTracingService.traceOutboxRecordProcessing(outboxRecord);
+
+        assertTrue(tracer.getSpans().isEmpty());
+        Map<String, String> headers = result.getHeaders();
+        assertEquals(1, headers.size());
+        assertEquals("header", headers.get("some"));
+    }
+
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/SimplePropagator.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/SimplePropagator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import io.micrometer.tracing.Span;
+import io.micrometer.tracing.TraceContext;
+import io.micrometer.tracing.propagation.Propagator;
+import io.micrometer.tracing.test.simple.SimpleSpanBuilder;
+import io.micrometer.tracing.test.simple.SimpleTraceContext;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class SimplePropagator implements Propagator {
+
+    public static final String TRACING_TRACE_ID = "traceId";
+    public static final String TRACING_SPAN_ID = "spanId";
+    private final SimpleTracer tracer;
+
+    @Override
+    @NotNull
+    public List<String> fields() {
+        return List.of(TRACING_TRACE_ID, TRACING_SPAN_ID);
+    }
+
+    @Override
+    public <C> void inject(TraceContext context, C carrier, Setter<C> setter) {
+        setter.set(carrier, TRACING_TRACE_ID, context.traceId());
+        setter.set(carrier, TRACING_SPAN_ID, context.spanId());
+    }
+
+    @Override
+    @NotNull
+    public <C> Span.Builder extract(@NotNull C carrier, Getter<C> getter) {
+        SimpleTraceContext traceContext = new SimpleTraceContext();
+
+        String traceId = getter.get(carrier, TRACING_TRACE_ID);
+        if (traceId != null)
+            traceContext.setTraceId(traceId);
+
+        String spanId = getter.get(carrier, TRACING_SPAN_ID);
+        if (spanId != null)
+            traceContext.setSpanId(spanId);
+
+        Span.Builder builder = new SimpleSpanBuilder(tracer);
+        builder.setParent(traceContext);
+        return builder;
+    }
+}

--- a/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/TracingAssertions.java
+++ b/outbox-kafka-spring/src/test/java/one/tomorrow/transactionaloutbox/tracing/TracingAssertions.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025 Tomorrow GmbH @ https://tomorrow.one
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package one.tomorrow.transactionaloutbox.tracing;
+
+import io.micrometer.tracing.test.simple.SimpleSpan;
+import io.micrometer.tracing.test.simple.SimpleTraceContext;
+import one.tomorrow.transactionaloutbox.model.OutboxRecord;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public interface TracingAssertions {
+
+    default void assertOutboxSpan(SimpleSpan outboxSpan, String traceId, String parentId, OutboxRecord outboxRecord) {
+        SimpleTraceContext outboxSpanContext = outboxSpan.context();
+        assertEquals(traceId, outboxSpanContext.traceId());
+        assertEquals(parentId, outboxSpanContext.parentId());
+        assertEquals(outboxRecord.getCreated().toInstant(), outboxSpan.getStartTimestamp());
+        assertTrue(outboxSpan.getEndTimestamp().isAfter(outboxRecord.getCreated().toInstant()));
+        assertNotNull(outboxSpanContext.spanId());
+    }
+
+    default void assertProcessingSpan(SimpleTraceContext processingSpanContext, String traceId, String parentId) {
+        assertEquals(traceId, processingSpanContext.traceId());
+        assertEquals(parentId, processingSpanContext.parentId());
+        assertNotNull(processingSpanContext.spanId());
+    }
+
+}


### PR DESCRIPTION
This provides an implementation for
[micrometer-tracing](https://docs.micrometer.io/tracing/reference/), the
default tracing abstraction for Spring Boot since 3.2 (as successor for
Spring Cloud Sleuth). Micrometer Tracing provides abstractions for
different tracing solutions on it's own. If something else like e.g.
Spring Cloud Sleuth or another tracing solution is used this should
still be possible by providing an implementation for `TracingService`.

What does the current solution provide?
* Adds a span for the message in the transactional-outbox (with start
  timestamp set to the time when the outbox record was created, and end
  timestamp set to the time when it's processed and sent to Kafka)
* Adds another span for the sending the message to Kafka (start
  timestamp is the time when the `ProducerRecord` is created, end
  timestamp is set when message sending got confirmed)
* Add tracing headers to the Kafka message, which can be extracted via
  `Propagator.extract` on consumer side.

The `micrometer-tracing` dependency shall not be pulled by this library,
but would have to be added by the application. In consequence, the
`MicrometerTracingService` bean is only available, if the application is
using `micrometer-tracing`, otherwise the `NoopTracingService` is used
as fallback implementation. The current solution via `@Primary` may not
be optimal, if this should become an issue, we could add our own
`@ConditionalOnMissingBean` annotation with the appropriate handling (to
not add a dependency on spring-boot, because also plain spring
applications shall be supported). Another alternative could be to
provide proper Autoconfiguration.

Closes #488